### PR TITLE
Add CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*]
+indent_style = tab
+insert_final_newline = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+branches:
+  only:
+    - master
+
+sudo: required
+
+language: generic
+
+services:
+  - docker
+
+cache:
+  directories:
+  - $HOME/.portage
+
+script:
+  - 'if [ "${TRAVIS_EVENT_TYPE}" != "cron" ]; then docker run --rm -ti -v "${HOME}"/.portage:/usr/portage -v "${PWD}":/overlay -w /overlay gentoo/stage3-amd64:latest /overlay/tests/runtests.sh; fi'
+  # - 'if [ "${TRAVIS_EVENT_TYPE}" == "cron" ]; then docker run --rm -ti -v "${PWD}/tests/newversionchecker.toml":/app/newversionchecker.toml -e GITHUB_API_TOKEN simonvanderveldt/newversionchecker; fi'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Audio overlay
+# Audio overlay [![Build Status](https://travis-ci.org/gentoo-audio/audio-overlay.svg?branch=master)](https://travis-ci.org/gentoo-audio/audio-overlay)
 
 Overlay containing pro audio applications
 
@@ -24,3 +24,9 @@ If you run into problems please [create an issue](https://github.com/gentoo-audi
 ## Automated quality control
 - GitHub's [branch protection](https://help.github.com/articles/about-protected-branches/) is enabled for the `master` branch
 - Changes can only be done using [pull requests](https://help.github.com/articles/about-pull-requests/) and need at least one approval
+- Pull requests can only be merged if they pass the automated tests, which are run by [Travis CI](https://travis-ci.org)
+- [Travis CI](https://travis-ci.org) also runs daily checks if a new version of one of the packages in this overlay is released. If so, an issue requesting a version bump will be created
+
+### Automated tests
+The following tests are run for every pull request:
+- [`repoman full`](https://wiki.gentoo.org/wiki/Repoman): Validate if the ebuilds, overlay and metadata are correct

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ If you run into problems please [create an issue](https://github.com/gentoo-audi
 ## Automated quality control
 - GitHub's [branch protection](https://help.github.com/articles/about-protected-branches/) is enabled for the `master` branch
 - Changes can only be done using [pull requests](https://help.github.com/articles/about-pull-requests/) and need at least one approval
-- Pull requests can only be merged if they pass the automated tests, which are run by [Travis CI](https://travis-ci.org)
-- [Travis CI](https://travis-ci.org) also runs daily checks if a new version of one of the packages in this overlay is released. If so, an issue requesting a version bump will be created
+- Pull requests can only be merged if they pass the automated tests, which are run by [Travis CI](https://travis-ci.org/gentoo-audio/audio-overlay)
+- [Travis CI](https://travis-ci.org/gentoo-audio/audio-overlay) also runs daily checks if a new version of one of the packages in this overlay is released. If so, an issue requesting a version bump will be created
 
 ### Automated tests
 The following tests are run for every pull request:

--- a/tests/newversionchecker.toml
+++ b/tests/newversionchecker.toml
@@ -1,0 +1,4 @@
+github_repo = "gentoo-audio/audio-overlay"
+check_interval = 24
+
+[projects]

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+set -x
+
+# Disable news messages from portage and disable rsync's output
+export FEATURES="-news" PORTAGE_RSYNC_EXTRA_OPTS="-q"
+
+# Update the portage tree and install dependencies
+emerge --sync
+emerge -q --buildpkg --usepkg dev-vcs/git app-portage/repoman
+
+# Run the tests
+repoman full --xmlparse


### PR DESCRIPTION
This is similar to the setup I'm already using for my personal overlay, it does a `repoman full` check for every PR.
Also it allows us to automatically check for new versions of git based projects using a very simply Python script I wrote https://github.com/simonvanderveldt/newversionchecker
If you want I can move or fork newversionchecker to the gentoo-audio org.

See https://travis-ci.org/simonvanderveldt/simonvanderveldt-overlay/builds/227322743?utm_source=github_status&utm_medium=notification for an example of the repoman check and https://github.com/simonvanderveldt/simonvanderveldt-overlay/pull/9 and this PR for an example of the feedback to a PR.

See https://travis-ci.org/simonvanderveldt/simonvanderveldt-overlay/builds/235029235 for an example of the output and https://github.com/simonvanderveldt/simonvanderveldt-overlay/issues/12 for an automatically created version bump issue.

For now I've disabled the version checks because we don't have any packages yet :P

Eventually I'd like to add actual merging of the package that was added/changed in a PR with the default USE flags, but that needs a bit of work.
Also the version check should get the repo's URL from the ebuilds in the repo instead of using a separate list in the config file, but I haven't had the time to determine how I can properly pull that info from portage.