### PR TITLE
Update bitwig:1 ebuild

### DIFF
--- a/media-sound/bitwig-studio/bitwig-studio-1.3.16.ebuild
+++ b/media-sound/bitwig-studio/bitwig-studio-1.3.16.ebuild
@@ -4,66 +4,72 @@
 # TODO
 # - Verify all runtime dependencies, min versions, and required flags
 # - Avoid bundled JRE?
-# - use EAPI=6
+# - What about bundled libs? Shouldn't they be removed?
+# - Install docs in correct location? (currently in /opt/bitwig-studio/resources/doc)
 
-EAPI=5
+EAPI=6
 inherit eutils fdo-mime unpacker
 
 DESCRIPTION="for creation and performance of your musical ideas on stage or in the studio."
-HOMEPAGE="http://bitwig.com/"
+HOMEPAGE="http://bitwig.com"
 SRC_URI="http://downloads.bitwig.com/${P}.deb"
 LICENSE="Bitwig"
 SLOT="1"
 KEYWORDS="~amd64"
 RESTRICT="mirror strip"
 
-IUSE="libav"
+IUSE="jack libav"
 
 DEPEND=""
 RDEPEND="${DEPEND}
-		app-arch/bzip2
-		dev-libs/expat
-		gnome-extra/zenity
-		media-libs/alsa-lib
-		media-libs/fontconfig
-		media-libs/freetype
-		media-libs/libpng:0/16
-		media-libs/mesa
-		media-sound/jack2
-		libav? ( media-video/libav )
-		sys-libs/zlib
-		x11-libs/cairo[xcb]
-		x11-libs/libX11
-		x11-libs/libXau
-		x11-libs/libXcursor
-		x11-libs/libXdmcp
-		x11-libs/libXext
-		x11-libs/libXfixes
-		x11-libs/libXrender
-		x11-libs/libdrm
-		x11-libs/libxcb
-		x11-libs/libxkbfile
-		x11-libs/pixman
-		x11-libs/xcb-util-wm
-		virtual/opengl
-		virtual/udev"
+	app-arch/bzip2
+	dev-libs/expat
+	gnome-extra/zenity
+	media-libs/alsa-lib
+	media-libs/fontconfig
+	media-libs/freetype
+	media-libs/libpng:0/16
+	media-libs/mesa
+	sys-libs/zlib
+	x11-libs/cairo[xcb]
+	x11-libs/libX11
+	x11-libs/libXau
+	x11-libs/libXcursor
+	x11-libs/libXdmcp
+	x11-libs/libXext
+	x11-libs/libXfixes
+	x11-libs/libXrender
+	x11-libs/libdrm
+	x11-libs/libxcb
+	x11-libs/libxkbfile
+	x11-libs/pixman
+	x11-libs/xcb-util-wm
+	virtual/opengl
+	virtual/udev
+	jack? ( virtual/jack )
+	libav? ( media-video/libav )"
+
+QA_PREBUILT="opt/bitwig-studio/lib/engine/*"
 
 S=${WORKDIR}
 
 src_install() {
 	BITWIG_HOME="/opt/bitwig-studio"
-
+	dodir ${BITWIG_HOME}
 	insinto ${BITWIG_HOME}
 	doins -r opt/bitwig-studio/*
-
-	fperms +x ${BITWIG_HOME}/bin32/BitwigPluginHost32
+	fperms +x ${BITWIG_HOME}/bitwig-studio
 	fperms +x ${BITWIG_HOME}/bin/BitwigPluginHost64
 	fperms +x ${BITWIG_HOME}/bin/BitwigStudioEngine
 	fperms +x ${BITWIG_HOME}/bin/bitwig-vamphost
-	fperms +x ${BITWIG_HOME}/bitwig-studio
-
+	fperms +x ${BITWIG_HOME}/bin/show-splash-gtk
+	fperms +x ${BITWIG_HOME}/bin32/BitwigPluginHost32
 	dosym ${BITWIG_HOME}/bitwig-studio /usr/bin/bitwig-studio
 
+	doicon -s scalable usr/share/icons/hicolor/scalable/apps/bitwig-studio.svg
+	make_desktop_entry ${PN} "Bitwig Studio" "" "" "MimeType=application/bitwig-project;application/bitwig-template"
+
+	doicon -s scalable -c mimetypes usr/share/icons/hicolor/scalable/mimetypes/*.svg
 	insinto /usr/share/mime/packages
 	doins usr/share/mime/packages/bitwig-studio.xml
 }
@@ -73,7 +79,7 @@ pkg_postinst() {
 	fdo-mime_desktop_database_update
 
 	if ! use libav; then
-		einfo "libav USE flag not set. Bitwig Studio require the avprobe and avconv tools"
+		einfo "libav USE flag not set. Bitwig Studio requires the avprobe and avconv tools"
 		einfo "for importing audio files."
 	fi
 }


### PR DESCRIPTION
@mrVanDalo this is the ebuild as I have it locally with some cleanups and additions (like adding a proper `.desktop` file, adding an icon, etc).
This one works for me doing some basic composition in it.
I do see some error message in the console when running it though, though it seems to be mainly a carla issue

```
❯ bitwig-studio 
JRE Path: //opt/bitwig-studio/lib/jre
Could not read directory contents: /usr/lib/carla/carla-bridge-native
Could not read directory contents: /usr/lib/carla/carla-bridge-lv2-gtk3
Could not read directory contents: /usr/lib/carla/libcarla_utils.so
Could not read directory contents: /usr/lib/carla/carla-bridge-lv2-modgui
Could not read directory contents: /usr/lib/carla/carla-bridge-lv2-qt5
Could not read directory contents: /usr/lib/carla/carla-bridge-lv2-x11
Could not read directory contents: /usr/lib/carla/carla-bridge-lv2-gtk2
Could not read directory contents: /usr/lib/carla/libcarla_interposer-x11.so
Could not read directory contents: /usr/lib/carla/carla-discovery-native
Could not read directory contents: /usr/lib/carla/libcarla_interposer-safe.so
Could not read directory contents: /usr/share/carla/ui_carla_parameter.py
Could not read directory contents: /usr/share/carla/paramspinbox.py
Could not read directory contents: /usr/share/carla/ui_carla_about.py
Could not read directory contents: /usr/share/carla/carla_widgets.py
Could not read directory contents: /usr/share/carla/carla_control.py
Could not read directory contents: /usr/share/carla/ui_carla_settings.py
Could not read directory contents: /usr/share/carla/ui_midipattern.py
Could not read directory contents: /usr/share/carla/carla_backend.py
Could not read directory contents: /usr/share/carla/carla_database.py
Could not read directory contents: /usr/share/carla/ui_carla_settings_driver.py
Could not read directory contents: /usr/share/carla/pixmapbutton.py
Could not read directory contents: /usr/share/carla/canvaspreviewframe.py
Could not read directory contents: /usr/share/carla/ui_carla_refresh.py
Could not read directory contents: /usr/share/carla/pixmapkeyboard.py
Could not read directory contents: /usr/share/carla/carla_skin.py
Could not read directory contents: /usr/share/carla/ui_carla_database.py
Could not read directory contents: /usr/share/carla/carla_settings.py
Could not read directory contents: /usr/share/carla/carla_modgui.py
Could not read directory contents: /usr/share/carla/ledbutton.py
Could not read directory contents: /usr/share/carla/ui_carla_plugin_presets.py
Could not read directory contents: /usr/share/carla/carla_utils.py
Could not read directory contents: /usr/share/carla/patchcanvas_theme.py
Could not read directory contents: /usr/share/carla/ui_carla_host.py
Could not read directory contents: /usr/share/carla/ui_carla_plugin_default.py
Could not read directory contents: /usr/share/carla/ui_inputdialog_value.py
Could not read directory contents: /usr/share/carla/draggablegraphicsview.py
Could not read directory contents: /usr/share/carla/ui_carla_edit.py
Could not read directory contents: /usr/share/carla/pianoroll.py
Could not read directory contents: /usr/share/carla/ui_carla_panel_time.py
Could not read directory contents: /usr/share/carla/ui_carla_plugin_compact.py
Could not read directory contents: /usr/share/carla/carla_shared.py
Could not read directory contents: /usr/share/carla/carla_config.py
Could not read directory contents: /usr/share/carla/carla_app.py
Could not read directory contents: /usr/share/carla/racklistwidget.py
Could not read directory contents: /usr/share/carla/carla_panels.py
Could not read directory contents: /usr/share/carla/ui_carla_plugin_calf.py
Could not read directory contents: /usr/share/carla/digitalpeakmeter.py
Could not read directory contents: /usr/share/carla/ui_carla_plugin_classic.py
Could not read directory contents: /usr/share/carla/resources_rc.py
Could not read directory contents: /usr/share/carla/ui_carla_about_juce.py
Could not read directory contents: /usr/share/carla/carla_backend_qt.py
Could not read directory contents: /usr/share/carla/patchcanvas.py
Could not read directory contents: /usr/share/carla/pixmapdial.py
Could not read directory contents: /usr/share/carla/externalui.py
Could not read directory contents: /usr/share/carla/carla_host.py
Could not read directory contents: /usr/lib/carla/carla-bridge-lv2-qt4
Error reading metadata for file carla.vst/styles/carlastyle.so:com.bitwig.flt.library.metadata.reader.exception.CouldNotReadMetadataException: could not read metadata: com.bitwig.flt.library.metadata.reader.exception.CouldNotReadMetadataException: could not read metadata: Could not read VST plug-in metadata
64 bit plugin host reported errors: Pluginhost returned non zero exit code 255

32 bit plugin host reported errors: Pluginhost returned non zero exit code 255
Error reading metadata for file carla.vst/libcarla_utils.so:com.bitwig.flt.library.metadata.reader.exception.CouldNotReadMetadataException: could not read metadata: com.bitwig.flt.library.metadata.reader.exception.CouldNotReadMetadataException: could not read metadata: Could not read VST plug-in metadata
64 bit plugin host reported errors: Pluginhost returned non zero exit code 255

32 bit plugin host reported errors: Pluginhost returned non zero exit code 255
Error reading metadata for file carla.vst/libcarla_interposer-x11.so:com.bitwig.flt.library.metadata.reader.exception.CouldNotReadMetadataException: could not read metadata: com.bitwig.flt.library.metadata.reader.exception.CouldNotReadMetadataException: could not read metadata: Could not read VST plug-in metadata
64 bit plugin host reported errors: Pluginhost returned non zero exit code 255

32 bit plugin host reported errors: Pluginhost returned non zero exit code 255
Error reading metadata for file carla.vst/libcarla_interposer-safe.so:com.bitwig.flt.library.metadata.reader.exception.CouldNotReadMetadataException: could not read metadata: com.bitwig.flt.library.metadata.reader.exception.CouldNotReadMetadataException: could not read metadata: Could not read VST plug-in metadata
64 bit plugin host reported errors: Pluginhost returned non zero exit code 255

32 bit plugin host reported errors: Pluginhost returned non zero exit code 255
Package Wave Alchemy/Wave Alchemy Loops & Samples (teaser):6 is not compatible with this version
Package Livid Instruments/Livid Instruments (teaser):4 is not compatible with this version
Package Cristian Vogel/Cristian Vogel Bitwig Lab:7 is not compatible with this version
Package Bitwig/Nektar's Acoustic Drums:5 is not compatible with this version
Package Bitwig/Tolcha's Clavinet:6 is not compatible with this version
Package Bitwig/Mathieu Pe's Electric Guitar is not compatible with this version
Package Bitwig/Percussion:7 is not compatible with this version
Package Bitwig/Tolcha's String Orchestra:6 is not compatible with this version
Package Bitwig/Bitwig Factory Device Presets:9 is not compatible with this version
Package Bitwig/Classic Drum Machines:9 is not compatible with this version
Package Bitwig/Bitwig Factory Clips:2 is not compatible with this version
Package Bitwig/Dr. Power's Wurlitzer:6 is not compatible with this version
Package Bitwig/Sampled Synths Vol. 1:8 is not compatible with this version
Package Bitwig/Bitwig Drum Machines:8 is not compatible with this version
Package Bitwig/Tolcha's Rhodes:6 is not compatible with this version
Package Bitwig/Volker's Fingered Bass:6 is not compatible with this version
Package Bitwig/Freak Ass's Vibraphone:6 is not compatible with this version
Package Bitwig/Freak Ass's Marimba:6 is not compatible with this version
Package Bitwig/Wundertuete Vol. 1:9 is not compatible with this version
Package Bitwig/Layered Instruments:7 is not compatible with this version
Package Bitwig/Sneaky's Acoustic Bass:7 is not compatible with this version
Package Irrupt/Irrupt Eurorack is not compatible with this version
Package Irrupt/Irrupt System:4 is not compatible with this version
Removing package Bitwig/Partner Collection (Teasers) because its dependency to Wave Alchemy/Wave Alchemy Loops & Samples (teaser):6 is not available
Removing package Bitwig/Artist Collection:7 because its dependency to Cristian Vogel/Cristian Vogel Bitwig Lab:7 is not available
Removing package Bitwig/Extended Collection:11 because its dependency to Bitwig/Nektar's Acoustic Drums:5 is not available
Removing package Bitwig/Essentials Collection:16 because its dependency to Bitwig/Bitwig Factory Device Presets:9 is not available
Removing package Bitwig/Partner Collection:10 because its dependency to Irrupt/Irrupt Eurorack is not available
```

Also, I get this when closing bitwig
```
Connection broken with client: null
java.io.EOFException
	at com.bitwig.ramona.serial.aAn.phI(SourceFile:261)
	at com.bitwig.ramona.serial.aAn.zOO(SourceFile:411)
	at bHt.jOe(SourceFile:764)
	at bHt.vyK(SourceFile:573)
	at bHt.vyK(SourceFile:552)
	at com.bitwig.ramona.protocol.VOQ.vyK(SourceFile:86)
	at bIr.def(SourceFile:383)
	at bIs.run(SourceFile:271)
```