### PR TITLE
media-sound/bitwig-studio fix window manager icon on GNOME

### DIFF
--- a/media-sound/bitwig-studio/bitwig-studio-1.3.16.ebuild
+++ b/media-sound/bitwig-studio/bitwig-studio-1.3.16.ebuild
@@ -82,9 +82,11 @@ src_install() {
 	dosym ${BITWIG_HOME}/bitwig-studio /usr/bin/bitwig-studio
 
 	doicon -s scalable usr/share/icons/hicolor/scalable/apps/bitwig-studio.svg
-	make_desktop_entry ${PN} "Bitwig Studio" "" "" \
-		"MimeType=application/bitwig-project;application/bitwig-template"
-
+	sed -i \
+	-e 's/Icon=.*/Icon=bitwig-studio/' \
+	-e 's/Categories=.*/Categories=AudioVideo;Audio;AudioVideoEditing/' \
+	usr/share/applications/bitwig-studio.desktop || die 'sed on desktop file failed'
+	domenu usr/share/applications/bitwig-studio.desktop
 	doicon -s scalable -c mimetypes usr/share/icons/hicolor/scalable/mimetypes/*.svg
 	insinto /usr/share/mime/packages
 	doins usr/share/mime/packages/bitwig-studio.xml


### PR DESCRIPTION
Whilst on GNOME the correct icon was shown in the application launcher it wasn't shown in the window manager (i.e. when alt-tabbing, or when viewing the "expose").
For reasons unknown to me this was caused by the `.desktop` file not having the same name as the executable. Since eutils's `dodesktop` effectively generates a `<executable>-<package name>.desktop` file, ie `bitwig-studio-bitwig-studio.desktop` this combo didn't work.

Fixed by replacing the `dodesktop` call with copying bitwig's own `.desktop` file.
Needed two `sed` statements to make it compliant with the freedesktop spec. I'll send a support mail to bitwig to request them to fix these two items upstream.