### PR TITLE
media-sound/bitwig: fixed dialog bug

### DIFF
--- a/media-sound/bitwig-studio/bitwig-studio-1.3.16.ebuild
+++ b/media-sound/bitwig-studio/bitwig-studio-1.3.16.ebuild
@@ -22,6 +22,7 @@ DEPEND=""
 RDEPEND="${DEPEND}
 	app-arch/bzip2
 	dev-libs/expat
+	gnome-extra/zenity
 	jack? ( virtual/jack )
 	media-libs/alsa-lib
 	media-libs/fontconfig


### PR DESCRIPTION
add accidentally deleted `gnome-extra/zenity` to make saving and loading possible again 