### PR TITLE
media-sound/bitwig repoman qa fix

### DIFF
--- a/media-sound/bitwig-studio/bitwig-studio-1.3.16.ebuild
+++ b/media-sound/bitwig-studio/bitwig-studio-1.3.16.ebuild
@@ -65,7 +65,6 @@ QA_PRESTRIPPED="
 	opt/bitwig-studio/lib/bitwig-studio/libxcb-xkb.so.1
 	opt/bitwig-studio/lib/jre/lib/amd64/libjfxwebkit.so"
 
-
 S=${WORKDIR}
 
 src_install() {


### PR DESCRIPTION
```
  ebuild.minorsyn               1
   media-sound/bitwig-studio/bitwig-studio-1.3.16.ebuild: Useless blank line on line: 68
```

Noticed this in the travis output of #12 
Now repoman is happy :)