### PR TITLE
Tests: repoman dont run xmlparse, include dev profiles

### DIFF
--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -9,4 +9,4 @@ emerge --sync
 emerge -q --buildpkg --usepkg dev-vcs/git app-portage/repoman
 
 # Run the tests
-repoman full --xmlparse
+repoman full -d


### PR DESCRIPTION
Small change, drops xmlparse because it doesn't actually do anything. See https://github.com/gentoo/portage/blob/a514908c7fd29e668dd775d7a32c949dbc8fe7d7/repoman/pym/repoman/argparser.py#L118. The `xml_parse` variable isn't used anywhere in repoman's codebase
Adding `-d` doesn't do anything in our case but gets rid of the unnecessary `Note: use --include-dev (-d) to check dependencies for 'dev' profiles` output