### PR TITLE
media-sound/drumkv1: Fix low res icon, update copyright header

### DIFF
--- a/media-sound/drumkv1/drumkv1-0.8.2.ebuild
+++ b/media-sound/drumkv1/drumkv1-0.8.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6

--- a/media-sound/drumkv1/drumkv1-0.8.2.ebuild
+++ b/media-sound/drumkv1/drumkv1-0.8.2.ebuild
@@ -1,1 +1,83 @@
-drumkv1-9999.ebuild
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit fdo-mime
+
+DESCRIPTION="An old-school all-digital drum-kit sampler synthesizer with stereo fx"
+HOMEPAGE="http://drumkv1.sourceforge.net/"
+if [[ ${PV} == *9999 ]]; then
+	inherit git-r3 autotools
+	EGIT_REPO_URI="https://github.com/rncbc/${PN}.git"
+	KEYWORDS=""
+else
+	SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+	KEYWORDS="~amd64"
+fi
+LICENSE="GPL-2+"
+SLOT="0"
+
+IUSE="debug qt5 standalone alsa lv2 osc"
+REQUIRED_USE="
+	|| ( standalone lv2 )
+	alsa? ( standalone )"
+
+RDEPEND="
+	!qt5? (
+		dev-qt/qtcore:4
+		dev-qt/qtgui:4
+	)
+	qt5? (
+		dev-qt/qtcore:5
+		dev-qt/qtgui:5
+		dev-qt/qtwidgets:5
+		dev-qt/qtxml:5
+	)
+	media-libs/libsndfile
+	standalone? ( virtual/jack )
+	alsa? ( media-libs/alsa-lib )
+	lv2? ( media-libs/lv2 )
+	osc? ( media-libs/liblo )
+"
+DEPEND="${RDEPEND}"
+
+src_prepare() {
+	# Fix to ensure this desktop file is used to get the application's icon
+	# Otherwise a low-res icon will be used
+	echo "StartupWMClass=drumkv1_jack" >> src/drumkv1.desktop.in
+	default
+}
+
+src_configure() {
+	if [[ ${PV} == *9999 ]]; then
+		eautoreconf
+	fi
+
+	# Disable stripping
+	echo "QMAKE_STRIP=" >> src/src_core.pri.in
+	echo "QMAKE_STRIP=" >> src/src_jack.pri.in
+
+	local -a myeconfargs=(
+		$(use_enable debug)
+		$(use_enable !qt5 qt4)
+		$(use_enable standalone jack)
+		$(use_enable alsa alsa-midi)
+		$(use_enable lv2)
+		$(use_enable osc liblo)
+	)
+	if use !qt5; then
+		export QT_SELECT=qt4
+	else
+		export QT_SELECT=qt5
+	fi
+	econf "${myeconfargs[@]}"
+}
+
+pkg_postinst() {
+	fdo-mime_mime_database_update
+}
+
+pkg_postrm() {
+	fdo-mime_mime_database_update
+}

--- a/media-sound/drumkv1/drumkv1-9999.ebuild
+++ b/media-sound/drumkv1/drumkv1-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6


### PR DESCRIPTION
Small change, adds the same fix as I already did in #30 and as it has been fixed in upstream `master` to the 0.8.2 version of drumkv