### PR TITLE
media-sound/drumkv1 fix eautoreconf QA warning

### DIFF
--- a/media-sound/drumkv1/drumkv1-9999.ebuild
+++ b/media-sound/drumkv1/drumkv1-9999.ebuild
@@ -42,11 +42,14 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}"
 
-src_configure() {
+src_prepare() {
 	if [[ ${PV} == *9999 ]]; then
 		eautoreconf
 	fi
+	default
+}
 
+src_configure() {
 	# Disable stripping
 	echo "QMAKE_STRIP=" >> src/src_core.pri.in
 	echo "QMAKE_STRIP=" >> src/src_jack.pri.in


### PR DESCRIPTION
Now the ebuild is the same as the one for samplv1