### PR TITLE
Test emerge random ebuild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,11 @@ matrix:
       script:
         - 'if [ "${TRAVIS_EVENT_TYPE}" != "cron" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ] ; then
           ./tests/emerge_new_or_changed_ebuilds.sh; fi'
-
-script:
-  - 'if [ "${TRAVIS_EVENT_TYPE}" == "cron" ]; then
-    docker run --rm -ti -v "${PWD}/tests/newversionchecker.toml":/app/newversionchecker.toml -e GITHUB_API_TOKEN simonvanderveldt/newversionchecker; fi'
+    - os: linux
+      env: BUILD_TYPE=newversioncheck # marker environment variable to make the build matrix more readable in the UI
+      services: docker
+      language: generic
+      sudo: required
+      script:
+        - 'if [ "${TRAVIS_EVENT_TYPE}" == "cron" ]; then
+          docker run --rm -ti -v "${PWD}/tests/newversionchecker.toml":/app/newversionchecker.toml -e GITHUB_API_TOKEN simonvanderveldt/newversionchecker; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
         - 'if [ "${TRAVIS_EVENT_TYPE}" != "cron" ]; then
           docker run --rm -ti -v "${HOME}"/.portage-pkgdir:/usr/portage/packages -v "${PWD}":/usr/local/portage -w /usr/local/portage gentoo/stage3-amd64:latest /usr/local/portage/tests/repoman.sh; fi'
     - os: linux
-      env: BUILD_TYPE=emerge # marker environment variable to make the build matrix more readable in the UI
+      env: BUILD_TYPE=emerge-changed # marker environment variable to make the build matrix more readable in the UI
       services: docker
       language: generic
       sudo: required
@@ -32,3 +32,11 @@ matrix:
       script:
         - 'if [ "${TRAVIS_EVENT_TYPE}" == "cron" ]; then
           docker run --rm -ti -v "${PWD}/tests/newversionchecker.toml":/app/newversionchecker.toml -e GITHUB_API_TOKEN simonvanderveldt/newversionchecker; fi'
+    - os: linux
+      env: BUILD_TYPE=emerge-random # marker environment variable to make the build matrix more readable in the UI
+      services: docker
+      language: generic
+      sudo: required
+      script:
+        - 'if [ "${TRAVIS_EVENT_TYPE}" == "cron" ]; then
+          ./tests/emerge_random_ebuild.sh; fi'

--- a/tests/emerge_random_ebuild.sh
+++ b/tests/emerge_random_ebuild.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Emerge a random ebuild out of all the ebuilds in the overlay
+# Used to do continuous tests if our ebuilds still work
+# As well as making sure Travis's cache of the master branch is filled
+set -ex
+
+# Pick a random ebuild
+EBUILD=$(find . -regex '.*\.ebuild$' | shuf -n1)
+
+# Emerge the ebuild in a clean stage3
+docker run --rm -ti -v "${HOME}"/.portage-pkgdir:/usr/portage/packages -v "${PWD}":/usr/local/portage -w /usr/local/portage gentoo/stage3-amd64:latest /usr/local/portage/tests/emerge_ebuild.sh "${EBUILD}"


### PR DESCRIPTION
This adds a simple script that uses the same foundation as the `emerge_new_or_changed_ebuilds.sh` script but does so for a random ebuild in the overlay.

Whilst ideally I'd like to do an emerge test for all the packages in the overlay every period that's simply going to take too long to finish. This is a means to still validate all our ebuilds continuously without the test taking ages.

Also because it's run from the `master` branch it serves as a way to feed the binary package cache for the `master` branch that's used by all pull requests. Which means we'll finally be able to make use of this cache for every PR :)