### PR TITLE
Tests: fix random emerge test

### DIFF
--- a/tests/emerge_random_ebuild.sh
+++ b/tests/emerge_random_ebuild.sh
@@ -5,7 +5,7 @@
 set -ex
 
 # Pick a random ebuild
-EBUILD=$(find . -regex '.*\.ebuild$' | shuf -n1)
+EBUILD=$(find . -regex '.*\.ebuild$' -printf '%P\n' | shuf -n1)
 
 # Emerge the ebuild in a clean stage3
 docker run --rm -ti -v "${HOME}"/.portage-pkgdir:/usr/portage/packages -v "${PWD}":/usr/local/portage -w /usr/local/portage gentoo/stage3-amd64:latest /usr/local/portage/tests/emerge_ebuild.sh "${EBUILD}"


### PR DESCRIPTION
There was a tiny error in the find command which which meant the returned paths started with `./`, which mean the emerge test failed :x

This changes fixes that problem :)