### PR TITLE
Travis: Remove marker env vars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ cache:
 matrix:
   include:
     - os: linux
-      env: BUILD_TYPE=repoman # marker environment variable to make the build matrix more readable in the UI
       services: docker
       language: generic
       sudo: required
@@ -17,7 +16,6 @@ matrix:
         - 'if [ "${TRAVIS_EVENT_TYPE}" != "cron" ]; then
           docker run --rm -ti -v "${HOME}"/.portage-pkgdir:/usr/portage/packages -v "${PWD}":/usr/local/portage -w /usr/local/portage gentoo/stage3-amd64:latest /usr/local/portage/tests/repoman.sh; fi'
     - os: linux
-      env: BUILD_TYPE=emerge-changed # marker environment variable to make the build matrix more readable in the UI
       services: docker
       language: generic
       sudo: required
@@ -33,7 +31,6 @@ matrix:
         - 'if [ "${TRAVIS_EVENT_TYPE}" == "cron" ]; then
           docker run --rm -ti -v "${PWD}/tests/newversionchecker.toml":/app/newversionchecker.toml -e GITHUB_API_TOKEN simonvanderveldt/newversionchecker; fi'
     - os: linux
-      env: BUILD_TYPE=emerge-random # marker environment variable to make the build matrix more readable in the UI
       services: docker
       language: generic
       sudo: required


### PR DESCRIPTION
I just ran into this issue that whilst we now have a nice cache on master the PRs are actually not able to make use of it because the env vars set per job in the Travis CI matrix also impact if the cache is shared.
If the env vars differ the cache isn't shared :(

Fixed by getting rid of the marker env vars.
Unfortunately this means no clear overview in travis which job is which. Luckily we only have four and they have pretty distinguishable runtimes, so imho whilst it's less than ideal it's still doable.
See https://github.com/travis-ci/travis-ci/issues/5898 for a related issue about this. 

I didn't remove the newversioncheck env var because we don't need to share cache with that job, which means we can at least easily identify that one :)