### PR TITLE
Add missing applications to new version check

### DIFF
--- a/tests/newversionchecker.toml
+++ b/tests/newversionchecker.toml
@@ -3,5 +3,11 @@ check_interval = 24
 
 [projects]
 drumkv1 = "https://github.com/rncbc/drumkv1"
+ladish = "https://github.com/LADI/ladish"
+mididings = "https://github.com/dsacre/mididings"
+praxis-live = "https://github.com/praxis-live/praxis-live"
+pure-data = "https://github.com/pure-data/pure-data"
 samplv1 = "https://github.com/rncbc/samplv1"
 sequencer64 = "https://github.com/ahlstromcj/sequencer64"
+setbfree = "https://github.com/pantherb/setBfree"
+synthv1 = "https://github.com/rncbc/synthv1"


### PR DESCRIPTION
These were missing, which means we didn't get automatic version bump issues when they create a new release