### PR TITLE
tests/refactor : try to stick to 80 letters per line

### DIFF
--- a/tests/emerge_ebuild.sh
+++ b/tests/emerge_ebuild.sh
@@ -13,7 +13,8 @@ EBUILD="${1}"
 echo "Emerging ${EBUILD}"
 
 # Disable news messages from portage and disable rsync's output
-export FEATURES="-news" PORTAGE_RSYNC_EXTRA_OPTS="-q"
+export FEATURES="-news" \
+       PORTAGE_RSYNC_EXTRA_OPTS="-q"
 
 # Update the portage tree
 emerge --sync
@@ -43,7 +44,16 @@ if [ -f "${PKG_CONF_FILE}" ]; then
 fi
 
 # Emerge dependencies first
-emerge --quiet-build --buildpkg --usepkg --onlydeps --autounmask=y --autounmask-continue=y "=${PKG_CATEGORY}/${PKG_NAME}"
+emerge \
+    --quiet-build \
+    --buildpkg \
+    --usepkg \
+    --onlydeps \
+    --autounmask=y \
+    --autounmask-continue=y \
+    "=${PKG_CATEGORY}/${PKG_NAME}"
 
 # Emerge the ebuild itself
-emerge -v "=${PKG_CATEGORY}/${PKG_NAME}"
+emerge \
+    --verbose \
+    "=${PKG_CATEGORY}/${PKG_NAME}"

--- a/tests/emerge_new_or_changed_ebuilds.sh
+++ b/tests/emerge_new_or_changed_ebuilds.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
+#
 # Determine which ebuilds are new or changed and emerge them
+
 set -ex
 
 # Get list of new or changed ebuilds
@@ -8,5 +10,13 @@ EBUILDS=($(git diff --name-only --diff-filter=d "${TRAVIS_BRANCH:-master}" | gre
 # Emerge the ebuilds
 for EBUILD in "${EBUILDS[@]}"
 do
-  docker run --rm -ti -v "${HOME}"/.portage-pkgdir:/usr/portage/packages -v "${PWD}":/usr/local/portage -w /usr/local/portage gentoo/stage3-amd64:latest /usr/local/portage/tests/emerge_ebuild.sh "${EBUILD}"
+    docker run \
+           --rm=true \
+           --tty=true \
+           --interactive=true \
+           --volume="${HOME}/.portage-pkgdir:/usr/portage/packages" \
+           --volume="${PWD}:/usr/local/portage" \
+           --workdir='/usr/local/portage' \
+           gentoo/stage3-amd64:latest \
+           /usr/local/portage/tests/emerge_ebuild.sh "${EBUILD}"
 done


### PR DESCRIPTION
I try to make scripts more readable : 

* use long options of shell commands (more descriptive)
* one option per line.