### PR TITLE
media-sound/bitwig-studio: fix jack2 dependencies

### DIFF
--- a/media-sound/bitwig-studio/bitwig-studio-1.3.16.ebuild
+++ b/media-sound/bitwig-studio/bitwig-studio-1.3.16.ebuild
@@ -23,7 +23,7 @@ RDEPEND="${DEPEND}
 	app-arch/bzip2
 	dev-libs/expat
 	gnome-extra/zenity
-	jack? ( virtual/jack )
+	jack? ( media-sound/jack2 )
 	media-libs/alsa-lib
 	media-libs/fontconfig
 	media-libs/freetype

--- a/media-sound/bitwig-studio/bitwig-studio-2.1.1.ebuild
+++ b/media-sound/bitwig-studio/bitwig-studio-2.1.1.ebuild
@@ -23,7 +23,7 @@ RDEPEND="${DEPEND}
 	app-arch/bzip2
 	dev-libs/expat
 	gnome-extra/zenity
-	jack? ( virtual/jack )
+	jack? ( media-sound/jack2 )
 	media-libs/alsa-lib
 	media-libs/fontconfig
 	media-libs/freetype

--- a/tests/packages/media-sound/bitwig-studio-1.3.16.conf
+++ b/tests/packages/media-sound/bitwig-studio-1.3.16.conf
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+cat >/etc/portage/package.use/bitwig-studio <<EOF
+media-libs/mesa -llvm
+EOF
+
+cat >>/etc/portage/make.conf <<EOF
+VIDEO_CARDS="intel"
+CPU_FLAGS_X86="sse mmxext mmx"
+EOF

--- a/tests/packages/media-sound/bitwig-studio-2.1.1.conf
+++ b/tests/packages/media-sound/bitwig-studio-2.1.1.conf
@@ -1,0 +1,1 @@
+bitwig-studio-1.3.16.conf


### PR DESCRIPTION
I tested it, bitwig needs API calls which only exist in jack2