### PR TITLE
media-sound/pure data fix missing slot operator QA issue

### DIFF
--- a/media-sound/pure-data/pure-data-0.47_p1.ebuild
+++ b/media-sound/pure-data/pure-data-0.47_p1.ebuild
@@ -25,8 +25,8 @@ SLOT="0"
 IUSE="alsa fftw jack"
 
 RDEPEND="
-	dev-lang/tcl
-	dev-lang/tk[truetype]
+	dev-lang/tcl:=
+	dev-lang/tk:=[truetype]
 	alsa? ( media-libs/alsa-lib )
 	jack? ( virtual/jack )
 	fftw? ( >=sci-libs/fftw-3 )"


### PR DESCRIPTION
Small change to fix the following repoman reported QA issues
```
media-sound/pure-data/pure-data-0.47_p1.ebuild: RDEPEND: 'dev-lang/tcl' matches more than one slot, please specify an explicit slot and/or use the := or :* slot operator
media-sound/pure-data/pure-data-0.47_p1.ebuild: RDEPEND: 'dev-lang/tk[truetype]' matches more than one slot, please specify an explicit slot and/or use the := or :* slot operator
```

AFAIK Pd needs to be rebuilt if tcl or tk is updated.
Since Pd needs tcl >=8.5 and all tcl/tk versions in the gentoo tree match this requirement I've gone with `:=` so Pd will work with all slots and will rebuild on update.