### PR TITLE
Tests: comment repoman output on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
       sudo: required
       script:
         - 'if [ "${TRAVIS_EVENT_TYPE}" != "cron" ]; then
-          docker run --rm -ti -v "${HOME}"/.portage-pkgdir:/usr/portage/packages -v "${PWD}":/usr/local/portage -w /usr/local/portage gentoo/stage3-amd64:latest /usr/local/portage/tests/repoman.sh; fi'
+          ./tests/repoman.sh; fi'
     - os: linux
       services: docker
       language: generic

--- a/tests/repoman.sh
+++ b/tests/repoman.sh
@@ -1,13 +1,10 @@
 #!/usr/bin/env bash
-# "Unit" test if overlay and ebuilds have basic issues
+# Run repoman in a clean amd64 stage3
 set -ex
 
-# Disable news messages from portage and disable rsync's output
-export FEATURES="-news" PORTAGE_RSYNC_EXTRA_OPTS="-q"
-
-# Update the portage tree and install dependencies
-emerge --sync
-emerge -q --buildpkg --usepkg dev-vcs/git app-portage/repoman
-
-# Run the tests
-repoman full -d
+docker run --rm -ti \
+  -e TRAVIS_BOT_GITHUB_TOKEN \
+  -v "${HOME}/.portage-pkgdir":/usr/portage/packages \
+  -v "${PWD}":/usr/local/portage \
+  -w /usr/local/portage gentoo/stage3-amd64:latest \
+  /usr/local/portage/tests/resources/repoman.sh

--- a/tests/repoman.sh
+++ b/tests/repoman.sh
@@ -3,6 +3,8 @@
 set -ex
 
 docker run --rm -ti \
+  -e TRAVIS_REPO_SLUG \
+  -e TRAVIS_PULL_REQUEST \
   -e TRAVIS_BOT_GITHUB_TOKEN \
   -v "${HOME}/.portage-pkgdir":/usr/portage/packages \
   -v "${PWD}":/usr/local/portage \

--- a/tests/resources/repoman.sh
+++ b/tests/resources/repoman.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# "Lint" using repoman if any ebuilds have basic issues
+# In case of a PR the result is added as a comment to the PR
+set -ex
+
+# Disable news messages from portage and disable rsync's output
+export FEATURES="-news" PORTAGE_RSYNC_EXTRA_OPTS="-q"
+
+# Update the portage tree and install dependencies
+emerge --sync
+emerge -q --buildpkg --usepkg dev-vcs/git app-portage/repoman
+
+# Run the tests
+repoman full -d

--- a/tests/resources/repoman.sh
+++ b/tests/resources/repoman.sh
@@ -8,7 +8,16 @@ export FEATURES="-news" PORTAGE_RSYNC_EXTRA_OPTS="-q"
 
 # Update the portage tree and install dependencies
 emerge --sync
-emerge -q --buildpkg --usepkg dev-vcs/git app-portage/repoman
+emerge -q --buildpkg --usepkg dev-vcs/git app-portage/repoman dev-python/pip
+pip install --user https://github.com/simonvanderveldt/travis-github-pr-bot/archive/master.zip
+PATH="~/.local/bin:$PATH"
 
 # Run the tests
-repoman full -d
+if ! repoman_output=$(repoman full -d -q); then
+  echo "$repoman_output"
+  echo "$repoman_output" | travis-bot --description "Repoman QA results:"
+  exit 1
+else
+  echo "$repoman_output"
+  echo "$repoman_output" | travis-bot --description "Repoman QA results:"
+fi


### PR DESCRIPTION
This PR enables Travis to post to PRs the results of the `repoman` run. See the comment directly below for an example :)

It uses https://github.com/koddsson/travis-github-pr-bot with some fixes/changes because it was specific to running `flake8` instead of any command line tool.
I'll try to get my changes upstreamed, but it's a small, single file project anyway, so not really a problem.