### PR TITLE
Tests: Use portage volume container

### DIFF
--- a/tests/emerge_ebuild.sh
+++ b/tests/emerge_ebuild.sh
@@ -15,9 +15,6 @@ echo "Emerging ${EBUILD}"
 # Disable news messages from portage and disable rsync's output
 export FEATURES="-news" PORTAGE_RSYNC_EXTRA_OPTS="-q"
 
-# Update the portage tree
-emerge --sync
-
 # Set portage's distdir to /tmp/distfiles
 # This is a workaround for a bug in portage/git-r3 where git-r3 can't
 # create the distfiles/git-r3 directory when no other distfiles have been

--- a/tests/emerge_new_or_changed_ebuilds.sh
+++ b/tests/emerge_new_or_changed_ebuilds.sh
@@ -5,8 +5,24 @@ set -ex
 # Get list of new or changed ebuilds
 EBUILDS=($(git diff --name-only --diff-filter=d "${TRAVIS_BRANCH:-master}" | grep '\.ebuild$')) || true
 
-# Emerge the ebuilds
+# Create volume container named "portage" with today's gentoo tree in it
+# Ensure the portage image is up to date
+docker pull gentoo/portage
+# Clean up in case an old volume container exists
+docker rm -f portage || true
+# Create the new volume container
+docker create --name portage gentoo/portage
+
+# Ensure the stage3 image is up to date
+docker pull gentoo/stage3-amd64
+
+# Emerge the ebuilds in a clean stage3
 for EBUILD in "${EBUILDS[@]}"
 do
-  docker run --rm -ti -v "${HOME}"/.portage-pkgdir:/usr/portage/packages -v "${PWD}":/usr/local/portage -w /usr/local/portage gentoo/stage3-amd64:latest /usr/local/portage/tests/emerge_ebuild.sh "${EBUILD}"
+  docker run --rm -ti \
+    --volumes-from portage \
+    -v "${HOME}/.portage-pkgdir":/usr/portage/packages \
+    -v "${PWD}":/usr/local/portage \
+    -w /usr/local/portage gentoo/stage3-amd64 \
+    /usr/local/portage/tests/emerge_ebuild.sh "${EBUILD}"
 done

--- a/tests/emerge_random_ebuild.sh
+++ b/tests/emerge_random_ebuild.sh
@@ -7,5 +7,21 @@ set -ex
 # Pick a random ebuild
 EBUILD=$(find . -regex '.*\.ebuild$' -printf '%P\n' | shuf -n1)
 
+# Create volume container named "portage" with today's gentoo tree in it
+# Ensure the portage image is up to date
+docker pull gentoo/portage
+# Clean up in case an old volume container exists
+docker rm -f portage || true
+# Create the new volume container
+docker create --name portage gentoo/portage
+
+# Ensure the stage3 image is up to date
+docker pull gentoo/stage3-amd64
+
 # Emerge the ebuild in a clean stage3
-docker run --rm -ti -v "${HOME}"/.portage-pkgdir:/usr/portage/packages -v "${PWD}":/usr/local/portage -w /usr/local/portage gentoo/stage3-amd64:latest /usr/local/portage/tests/emerge_ebuild.sh "${EBUILD}"
+docker run --rm -ti \
+  --volumes-from portage \
+  -v "${HOME}/.portage-pkgdir":/usr/portage/packages \
+  -v "${PWD}":/usr/local/portage \
+  -w /usr/local/portage gentoo/stage3-amd64 \
+  /usr/local/portage/tests/emerge_ebuild.sh "${EBUILD}"

--- a/tests/repoman.sh
+++ b/tests/repoman.sh
@@ -2,11 +2,24 @@
 # Run repoman in a clean amd64 stage3
 set -ex
 
+# Create volume container named "portage" with today's gentoo tree in it
+# Ensure the portage image is up to date
+docker pull gentoo/portage
+# Clean up in case an old volume container exists
+docker rm -f portage || true
+# Create the new volume container
+docker create --name portage gentoo/portage
+
+# Ensure the stage3 image is up to date
+docker pull gentoo/stage3-amd64
+
+# Run the repoman tests in a clean stage3
 docker run --rm -ti \
   -e TRAVIS_REPO_SLUG \
   -e TRAVIS_PULL_REQUEST \
   -e TRAVIS_BOT_GITHUB_TOKEN \
+  --volumes-from portage \
   -v "${HOME}/.portage-pkgdir":/usr/portage/packages \
   -v "${PWD}":/usr/local/portage \
-  -w /usr/local/portage gentoo/stage3-amd64:latest \
+  -w /usr/local/portage gentoo/stage3-amd64 \
   /usr/local/portage/tests/resources/repoman.sh

--- a/tests/resources/repoman.sh
+++ b/tests/resources/repoman.sh
@@ -6,8 +6,7 @@ set -ex
 # Disable news messages from portage and disable rsync's output
 export FEATURES="-news" PORTAGE_RSYNC_EXTRA_OPTS="-q"
 
-# Update the portage tree and install dependencies
-emerge --sync
+# Install dependencies
 emerge -q --buildpkg --usepkg dev-vcs/git app-portage/repoman dev-python/pip
 pip install --user https://github.com/simonvanderveldt/travis-github-pr-bot/archive/master.zip
 PATH="~/.local/bin:$PATH"


### PR DESCRIPTION
Instead of syncing the entire tree every run.
This makes sure the tests are more stable, quicker and we don't hammer the gentoo mirror's all the time with our syncs