### PR TITLE
add media-libs/libmonome

### DIFF
--- a/media-libs/libmonome/libmonome-9999.ebuild
+++ b/media-libs/libmonome/libmonome-9999.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python2_7 python3_4 python3_5 python3_6 )
+PYTHON_REQ_USE='threads(+)'
+
+inherit git-r3 python-any-r1 waf-utils
+
+DESCRIPTION="Library for easy interaction with monome devices"
+HOMEPAGE="https://github.com/monome/libmonome"
+EGIT_REPO_URI="https://github.com/monome/libmonome.git"
+KEYWORDS=""
+LICENSE="ISC"
+SLOT="0"
+
+IUSE="osc -python udev"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+RDEPEND="udev? ( virtual/libudev )
+	osc? ( media-libs/liblo )
+	python? ( dev-python/cython )"
+DEPEND="${RDEPEND}"
+
+src_configure() {
+	local mywafconfargs=(
+		$(usex osc "" --disable-osc)
+		$(usex python --enable-python "")
+		$(usex udev "" --disable-udev)
+	)
+	waf-utils_src_configure ${mywafconfargs[@]}
+}

--- a/media-libs/libmonome/metadata.xml
+++ b/media-libs/libmonome/metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<name>Simon van der Veldt</name>
+		<email>simon.vanderveldt+audio-overlay@gmail.com</email>
+	</maintainer>
+</pkgmetadata>


### PR DESCRIPTION
libmonome is needed to work with monome grid's https://monome.org/grid/
Apparently no one so far made an ebuild for it so here we go :)

Once merged I'll create a PR to update the monome Linux docs so people know they can install libmonome easily when using gentoo :)