### PR TITLE
media-sounds/serialosc add version 1.4.1

### DIFF
--- a/media-sound/serialosc/serialosc-1.4.1.ebuild
+++ b/media-sound/serialosc/serialosc-1.4.1.ebuild
@@ -1,0 +1,1 @@
+serialosc-9999.ebuild

--- a/media-sound/serialosc/serialosc-9999.ebuild
+++ b/media-sound/serialosc/serialosc-9999.ebuild
@@ -13,7 +13,12 @@ DESCRIPTION="Multi-device, bonjour-capable monome OSC server"
 HOMEPAGE="https://github.com/monome/serialosc"
 EGIT_REPO_URI="https://github.com/monome/serialosc.git"
 EGIT_SUBMODULES=( "*" "-third-party/libuv" )
-KEYWORDS=""
+if [[ ${PV} == *9999 ]]; then
+	KEYWORDS=""
+else
+	EGIT_COMMIT="v${PV}"
+	KEYWORDS="~amd64"
+fi
 LICENSE="ISC"
 SLOT="0"
 
@@ -22,7 +27,7 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 RDEPEND="virtual/libudev
 	media-libs/liblo
-	media-libs/libmonome
+	>=media-libs/libmonome-1.4.1
 	dev-libs/libuv
 	zeroconf? ( net-dns/avahi[mdnsresponder-compat] )"
 DEPEND="${RDEPEND}"


### PR DESCRIPTION
Fixes #155 

Uses git instead of the release tarball because the tarball isn't complete (missing git submodules and the gitrev it was created from).