### PR TITLE
Add script to publish package list to GitHub Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 metadata/md5-cache
+docs/site

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,34 +6,42 @@ cache:
   directories:
   - $HOME/.portage-pkgdir
 
-matrix:
+jobs:
   include:
-    - os: linux
+    - if: type = pull_request
+      os: linux
       services: docker
       language: generic
       sudo: required
-      script:
-        - 'if [ "${TRAVIS_EVENT_TYPE}" != "cron" ]; then
-          ./tests/repoman.sh; fi'
-    - os: linux
+      script: ./tests/repoman.sh
+    - if: type = pull_request
+      os: linux
       services: docker
       language: generic
       sudo: required
-      script:
-        - 'if [ "${TRAVIS_EVENT_TYPE}" != "cron" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ] ; then
-          ./tests/emerge-new-or-changed-ebuilds.sh; fi'
-    - os: linux
-      env: BUILD_TYPE=newversioncheck # marker environment variable to make the build matrix more readable in the UI
+      script: ./tests/emerge-new-or-changed-ebuilds.sh
+    - if: type != pull_request AND type != cron
+      os: linux
       services: docker
       language: generic
       sudo: required
-      script:
-        - 'if [ "${TRAVIS_EVENT_TYPE}" == "cron" ]; then
-          ./tests/newversioncheck.sh; fi'
-    - os: linux
+      script: ./docs/generate-site.sh
+      deploy:
+        provider: pages
+        skip-cleanup: true
+        local-dir: docs/site
+        github-token: $GITHUB_API_TOKEN
+        target-branch: gh-pages
+        keep-history: false
+    - if: type = cron
+      os: linux
       services: docker
       language: generic
       sudo: required
-      script:
-        - 'if [ "${TRAVIS_EVENT_TYPE}" == "cron" ]; then
-          ./tests/emerge-random-ebuild.sh; fi'
+      script: ./tests/newversioncheck.sh
+    - if: type = cron
+      os: linux
+      services: docker
+      language: generic
+      sudo: required
+      script: ./tests/emerge-random-ebuild.sh

--- a/docs/generate-site.sh
+++ b/docs/generate-site.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Create markdown file with an overview of all our packages
+# Ready to be rendered into a site by GitHub Pages
+set -ex
+
+# Create volume container named "portage" with today's gentoo tree in it
+# Ensure the portage image is up to date
+docker pull gentoo/portage
+# Clean up in case an old volume container exists
+docker rm -f portage || true
+# Create the new volume container
+docker create --name portage gentoo/portage
+
+# Run overlay-packagelist to render our template
+mkdir docs/site
+docker run --rm -ti \
+  --volumes-from portage \
+  -v "${HOME}/.portage-pkgdir":/usr/portage/packages \
+  -v "${PWD}":/usr/local/portage \
+  -w /usr/local/portage simonvanderveldt/overlay-packagelist \
+  docs/index.md.j2 > docs/site/index.md

--- a/docs/index.md.j2
+++ b/docs/index.md.j2
@@ -1,0 +1,27 @@
+Gentoo overlay containing pro audio applications.
+
+## How to use this overlay
+- Add the following entry to [`/etc/portage/repos.conf`](https://wiki.gentoo.org/wiki//etc/portage/repos.conf) and sync using `emerge --sync`
+```ini
+[audio-overlay]
+location = /<path>/<to>/<your>/<overlays>/audio-overlay
+sync-type = git
+sync-uri = https://github.com/gentoo-audio/audio-overlay.git
+auto-sync = yes
+```
+- Or if you use [layman](https://wiki.gentoo.org/wiki/Layman) add the overlay using `layman -a audio-overlay` and sync using `layman -s audio-overlay`
+
+## Contact
+Join us at the `#proaudio-overlay` channel at `irc.freenode.org` or [create an issue](https://github.com/gentoo-audio/audio-overlay/issues/new).
+
+
+## Packages
+{% for category, category_packages in packages.items() %}
+### {{ category }}
+{% for package in category_packages %}
+#### {{ package.name }}
+Homepage: [{{ package.homepage }}]({{ package.homepage_url }})<br>
+{{ package.description }}<br>
+Available versions: {{ package.versions|join(', ') }}
+{% endfor %}
+{% endfor %}


### PR DESCRIPTION
This PR adds automatic publishing of an overview of all the packages in our overlay to the `gh-pages` branch, which is used by GitHub Pages to publish to https://gentoo-audio.github.io/audio-overlay
This gives us a free site we can use to link to for anyone interested in the overlay/which packages it contains.
The build uses https://github.com/simonvanderveldt/overlay-packagelist which is a pretty simple Python script that uses portage to return a list of all the packages and their properties which can then be used in a template. The page that's generated is based on a jinja2 template (`docs/index.md.j2`) so we can customize it as we please. I want to add the basic usage instructions to it in the future.

Based on some feedback from the kind folks at Travis I've also switched out `.travis.yml` to make use of [conditional jobs](https://docs.travis-ci.com/user/conditional-builds-stages-jobs) instead of our manual/custom build matrix. This makes the file a lot easier to read and will only add/show the relevant jobs for every type of build. I.e. for a PR only the repoman and emerge-new-changed-ebuild jobs will be started/shown. This makes it a bit easier to navigate the Travis builds and jobs :)