### PR TITLE
Travis: switch back to matrix builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
   directories:
   - $HOME/.portage-pkgdir
 
-jobs:
+matrix:
   include:
     - if: type = pull_request
       os: linux


### PR DESCRIPTION
Small change so the job config in Travis doesn't show the whole build config.

Difference for reference:
Current situation without matrix, the whole build config is shown when looking at a job's config
![image](https://user-images.githubusercontent.com/204286/35470908-0b1c38b6-0352-11e8-99e5-79d5ab26dc82.png)

New situation using matrix, only the chosen job's config is shown
![image](https://user-images.githubusercontent.com/204286/35470910-254c4a5a-0352-11e8-8b08-595aa2b7f5ba.png)