### PR TITLE
Add qtopengl dependency

### DIFF
--- a/media-sound/cadence/cadence-9999-r2.ebuild
+++ b/media-sound/cadence/cadence-9999-r2.ebuild
@@ -16,7 +16,7 @@ SLOT="0"
 IUSE="-pulseaudio a2jmidid ladish"
 
 RDEPEND="virtual/jack
-	dev-python/PyQt4[X,svg,${PYTHON_USEDEP}]
+	dev-python/PyQt4[X,svg,opengl,${PYTHON_USEDEP}]
 	dev-python/dbus-python
 	a2jmidid? ( media-sound/a2jmidid )
 	ladish? ( >=media-sound/ladish-9999 )


### PR DESCRIPTION
Cadence supports opengl via PyQt4.QtOpenGL, for what there is use flag.