### PR TITLE
Tests: Use binpkg-multi-instance for better caching

### DIFF
--- a/tests/emerge-ebuild.sh
+++ b/tests/emerge-ebuild.sh
@@ -27,5 +27,6 @@ docker run --rm -ti \
   --volumes-from portage \
   -v "${HOME}/.portage-pkgdir":/usr/portage/packages \
   -v "${PWD}":/usr/local/portage \
-  -w /usr/local/portage gentoo/stage3-amd64 \
+  -w /usr/local/portage \
+  gentoo/stage3-amd64 \
   /usr/local/portage/tests/resources/emerge-ebuild.sh "${EBUILD}"

--- a/tests/resources/emerge-ebuild.sh
+++ b/tests/resources/emerge-ebuild.sh
@@ -13,7 +13,7 @@ EBUILD="${1}"
 echo "Emerging ${EBUILD}"
 
 # Disable news messages from portage and disable rsync's output
-export FEATURES="-news" PORTAGE_RSYNC_EXTRA_OPTS="-q"
+export FEATURES="binpkg-multi-instance -news" PORTAGE_RSYNC_EXTRA_OPTS="-q"
 
 # Set portage's distdir to /tmp/distfiles
 # This is a workaround for a bug in portage/git-r3 where git-r3 can't


### PR DESCRIPTION
`binpkg-multi-use` allows a binary package host to store binary packages for different USE flag combinations, meaning we'll get less cache misses because of differences in USE flags for common packages :)

This should help builds on Travis so they take less time/don't time out.

`binpkg-multi-use` was introduced as fix to this bug https://bugs.gentoo.org/150031