### PR TITLE
Tests: fix feedback to github for our own PRs

### DIFF
--- a/tests/repoman.sh
+++ b/tests/repoman.sh
@@ -18,6 +18,7 @@ docker run --rm -ti \
   -e TRAVIS_REPO_SLUG \
   -e TRAVIS_PULL_REQUEST \
   -e TRAVIS_BOT_GITHUB_TOKEN \
+  -e TRAVIS_SECURE_ENV_VARS \
   --volumes-from portage \
   -v "${HOME}/.portage-pkgdir":/usr/portage/packages \
   -v "${PWD}":/usr/local/portage \


### PR DESCRIPTION
Small fix to make sure we still receive the repoman results as comments on our own (non 3rd party) PRs