### PR TITLE
media-sound/ladish: make compatible with lash (wrapper)

### DIFF
--- a/media-sound/ladish/ladish-9999.ebuild
+++ b/media-sound/ladish/ladish-9999.ebuild
@@ -31,7 +31,7 @@ RDEPEND="media-libs/alsa-lib
 	media-sound/jack2[dbus]
 	sys-apps/dbus
 	dev-libs/expat
-	lash? ( !media-sound/lash )
+	lash? ( !media-sound/lash[-ladish] )
 	gtk? (
 		dev-libs/glib
 		dev-libs/dbus-glib


### PR DESCRIPTION
There is package media-sound/lash-9998 from proaudio, intended to be wrapper for packages, supporting lash.
While proaudio version doesn't have this restricting dependency, i had it in local overlay in proposed form, and it is ok.