### PR TITLE
media-sound/bitwig-studio update SRC_URI

### DIFF
--- a/media-sound/bitwig-studio/bitwig-studio-1.3.16.ebuild
+++ b/media-sound/bitwig-studio/bitwig-studio-1.3.16.ebuild
@@ -11,7 +11,7 @@ inherit eutils unpacker xdg-utils gnome2-utils
 
 DESCRIPTION="Multi-platform music-creation system for production, performance and DJing"
 HOMEPAGE="http://bitwig.com"
-SRC_URI="http://downloads.bitwig.com/${P}.deb"
+SRC_URI="https://downloads.bitwig.com/stable/${PV}/${P}.deb"
 LICENSE="Bitwig"
 SLOT="0"
 KEYWORDS="~amd64"

--- a/media-sound/bitwig-studio/bitwig-studio-2.1.4.ebuild
+++ b/media-sound/bitwig-studio/bitwig-studio-2.1.4.ebuild
@@ -11,7 +11,7 @@ inherit eutils unpacker xdg-utils gnome2-utils
 
 DESCRIPTION="Multi-platform music-creation system for production, performance and DJing"
 HOMEPAGE="http://bitwig.com"
-SRC_URI="http://downloads.bitwig.com/${P}.deb"
+SRC_URI="https://downloads.bitwig.com/stable/${PV}/${P}.deb"
 LICENSE="Bitwig"
 SLOT="0"
 KEYWORDS="~amd64"


### PR DESCRIPTION
Apparently the `SRC_URI` we were using no longer works.
Good thing, because now we're using `HTTPS` :)