### PR TITLE
media-sound/mididings: enable python 3.6

### DIFF
--- a/media-sound/mididings/mididings-20120419.ebuild
+++ b/media-sound/mididings/mididings-20120419.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python{2_7,3_4,3_5} )
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 PYTHON_REQ_USE="tk?"
 inherit distutils-r1
 

--- a/media-sound/mididings/mididings-99999999.ebuild
+++ b/media-sound/mididings/mididings-99999999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python{2_7,3_4,3_5} )
+PYTHON_COMPAT=( python{2_7,3_4,3_5,3_6} )
 PYTHON_REQ_USE="tk?"
 inherit distutils-r1
 


### PR DESCRIPTION
Shouldn't need a revbump because --newuse should take care of triggering rebuilds.