### PR TITLE
media-sound/cadence fix Python dependencies

### DIFF
--- a/media-sound/cadence/cadence-9999-r6.ebuild
+++ b/media-sound/cadence/cadence-9999-r6.ebuild
@@ -15,15 +15,31 @@ SLOT="0"
 
 IUSE="-pulseaudio a2jmidid ladish opengl"
 
-RDEPEND="media-sound/jack2[dbus]
+RDEPEND="${PYTHON_DEPS}
+	media-sound/jack2[dbus]
 	dev-python/PyQt5[dbus,gui,opengl?,svg,widgets,${PYTHON_USEDEP}]
-	dev-python/dbus-python
+	dev-python/dbus-python[${PYTHON_USEDEP}]
 	a2jmidid? ( media-sound/a2jmidid[dbus] )
 	ladish? ( >=media-sound/ladish-9999 )
 	pulseaudio? ( media-sound/pulseaudio[jack] )"
 DEPEND=${RDEPEND}
 
 PATCHES=( "${FILESDIR}"/${PN}-add-skip-stripping.patch )
+
+src_prepare() {
+	sed -i -e "s/python3/${EPYTHON}/" \
+		data/cadence \
+		data/cadence-aloop-daemon \
+		data/cadence-jacksettings \
+		data/cadence-logs \
+		data/cadence-render \
+		data/cadence-session-start \
+		data/catarina \
+		data/catia \
+		data/claudia \
+		data/claudia-launcher || die "sed failed"
+	default
+}
 
 src_compile() {
 	myemakeargs=(PREFIX="/usr"


### PR DESCRIPTION
Also replace python version used in executable with scripts with

Fixes #187
Fixes #189 

This will probably time out on CI, it has to build some big Qt packages
[edit] And it did indeed time out. Validated locally, emerge is working fine, no QA issues.