### PR TITLE
docs: use monospacec font for versions

### DIFF
--- a/docs/generate-site.sh
+++ b/docs/generate-site.sh
@@ -12,7 +12,9 @@ docker rm -f portage || true
 docker create --name portage gentoo/portage
 
 # Run overlay-packagelist to render our template
-mkdir docs/site
+mkdir -p docs/site
+rm -rf docs/site/*
+
 docker run --rm -ti \
   --volumes-from portage \
   -v "${HOME}/.portage-pkgdir":/usr/portage/packages \

--- a/docs/index.md.j2
+++ b/docs/index.md.j2
@@ -22,6 +22,6 @@ Join us at the `#proaudio-overlay` channel at `irc.freenode.org` or [create an i
 #### {{ package.name }}
 Homepage: [{{ package.homepage }}]({{ package.homepage_url }})<br>
 {{ package.description }}<br>
-Available versions: {{ package.versions|join(', ') }}
+Available versions: {% for version in package.versions %}`{{ version }}`{% if not loop.last %}, {% endif %}{% endfor %}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
Small change to the docs template to show the versions in monospace font/code blocks, they are a bit unreadable in the normal font, especially for packages with longer versions when we have several versions of them

before
![image](https://user-images.githubusercontent.com/204286/45265394-7e0a8b80-b44a-11e8-9caa-fb14290ea520.png)

after
![image](https://user-images.githubusercontent.com/204286/45265398-8f539800-b44a-11e8-86fc-abd9ac5d0e9f.png)

Also a small change to cleanup existing docs when (re)generating them/make the docs generation work also when docs have already been generated before.