### PR TITLE
Add media-sound/carla

### DIFF
--- a/media-sound/carla/carla-9999.ebuild
+++ b/media-sound/carla/carla-9999.ebuild
@@ -1,0 +1,105 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python3_{4,5,6,7} )
+inherit python-single-r1 xdg-utils gnome2-utils
+
+DESCRIPTION="Fully-featured audio plugin host, supports many audio drivers and plugin formats"
+HOMEPAGE="http://kxstudio.linuxaudio.org/Applications:Carla"
+if [[ ${PV} == *9999 ]]; then
+	# Disable submodules to prevent external plugins from being built and installed
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/falkTX/Carla.git"
+	EGIT_SUBMODULES=()
+	KEYWORDS=""
+else
+	SRC_URI="https://github.com/falkTX/Carla/archive/${PV}.tar.gz -> ${P}.tar.gz"
+	RESTRICT="mirror"
+	KEYWORDS="~amd64"
+fi
+LICENSE="GPL-2 LGPL-3"
+SLOT="0"
+
+IUSE="alsa ffmpeg gtk gtk2 libav opengl osc -pulseaudio rdf sf2 sndfile X"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+RDEPEND="${PYTHON_DEPS}
+	dev-python/PyQt5[gui,opengl?,svg,widgets,${PYTHON_USEDEP}]
+	virtual/jack
+	alsa? ( media-libs/alsa-lib )
+	ffmpeg? (
+		libav? ( media-video/libav:0= )
+		!libav? ( media-video/ffmpeg:0= )
+	)
+	gtk? ( x11-libs/gtk+:3 )
+	gtk2? ( x11-libs/gtk+:2 )
+	osc? (
+		media-libs/liblo
+		media-libs/pyliblo
+	)
+	pulseaudio? ( media-sound/pulseaudio )
+	rdf? ( dev-python/rdflib )
+	sf2? ( media-sound/fluidsynth )
+	sndfile? ( media-libs/libsndfile )
+	X? ( x11-base/xorg-server )"
+DEPEND=${RDEPEND}
+
+src_prepare() {
+	sed -i -e "s|exec \$PYTHON|exec ${PYTHON}|" \
+		data/carla \
+		data/carla-control \
+		data/carla-database \
+		data/carla-jack-multi \
+		data/carla-jack-single \
+		data/carla-patchbay \
+		data/carla-rack \
+		data/carla-settings || die "sed failed"
+	default
+}
+
+src_compile() {
+	myemakeargs=(
+		SKIP_STRIPPING=true
+		HAVE_ZYN_DEPS=false
+		HAVE_ZYN_UI_DEPS=false
+		HAVE_QT4=false
+		HAVE_QT5=true
+		HAVE_PYQT5=true
+		DEFAULT_QT=5
+		HAVE_ALSA=$(usex alsa true false)
+		HAVE_FFMPEG=$(usex ffmpeg true false)
+		HAVE_FLUIDSYNTH=$(usex sf2 true false)
+		HAVE_GTK2=$(usex gtk2 true false)
+		HAVE_GTK3=$(usex gtk true false)
+		HAVE_LIBLO=$(usex osc true false)
+		HAVE_PULSEAUDIO=$(usex pulseaudio true false)
+		HAVE_SNDFILE=$(usex sndfile true false)
+		HAVE_X11=$(usex X true false)
+	)
+
+	# Print which options are enabled/disabled
+	make features PREFIX="/usr" "${myemakeargs[@]}"
+
+	emake PREFIX="/usr" "${myemakeargs[@]}"
+}
+
+src_install() {
+	emake DESTDIR="${D}" PREFIX="/usr" "${myemakeargs[@]}" install
+	if ! use osc; then
+		find "${D}/usr" -iname "carla-control*" | xargs rm
+	fi
+}
+
+pkg_postinst() {
+	xdg_mimeinfo_database_update
+	xdg_desktop_database_update
+	gnome2_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_mimeinfo_database_update
+	xdg_desktop_database_update
+	gnome2_icon_cache_update
+}

--- a/media-sound/carla/metadata.xml
+++ b/media-sound/carla/metadata.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>simon.vanderveldt+audio-overlay@gmail.com</email>
+		<name>Simon van der Veldt</name>
+	</maintainer>
+	<use>
+		<flag name="gtk2">Use gtk-2 instead of gtk-3</flag>
+		<flag name="rdf">Enable LADSPA-RDF support</flag>
+		<flag name="sf2">Enable builtin SF2 sample support using <pkg>media-sound/fluidsynth</pkg></flag>
+	</use>
+</pkgmetadata>

--- a/tests/resources/newversionchecker.toml
+++ b/tests/resources/newversionchecker.toml
@@ -3,6 +3,7 @@ check_interval = 24
 
 [projects]
 artyfx = "https://github.com/openAVproductions/openAV-ArtyFX"
+carla = "https://github.com/falkTX/Carla"
 drumkv1 = "https://github.com/rncbc/drumkv1"
 ladish = "https://github.com/LADI/ladish"
 libmonome = "https://github.com/monome/libmonome"
@@ -12,7 +13,7 @@ padthv1 = "https://github.com/rncbc/padthv1"
 pure-data = "https://github.com/pure-data/pure-data"
 samplv1 = "https://github.com/rncbc/samplv1"
 sequencer64 = "https://github.com/ahlstromcj/sequencer64"
-setbfree = "https://github.com/pantherb/setBfree"
 serialosc = "https://github.com/monome/serialosc"
+setbfree = "https://github.com/pantherb/setBfree"
 sorcer = "https://github.com/openAVproductions/openAV-Sorcer"
 synthv1 = "https://github.com/rncbc/synthv1"


### PR DESCRIPTION
Adds http://kxstudio.linuxaudio.org/Applications:Carla

This is based on the version I've had in my personal overlay for some time (https://github.com/simonvanderveldt/simonvanderveldt-overlay/tree/master/media-sound/carla), but updated based on the rather large amount of changes that have happened during all the RCs for 2.0

Since there's no release yet of 2.0 this currently only contains a live/9999 ebuild, will add a versioned one once 2.0 is released.