### PR TITLE
media-sound/sc3-plugins: remove redundant patch from live ebuild

### DIFF
--- a/media-sound/sc3-plugins/sc3-plugins-3.9.1.ebuild
+++ b/media-sound/sc3-plugins/sc3-plugins-3.9.1.ebuild
@@ -1,1 +1,41 @@
-sc3-plugins-9999.ebuild
+# Copyright 1999-2019 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit git-r3 cmake-utils
+
+DESCRIPTION="Third party plugins for SuperCollider"
+HOMEPAGE="https://github.com/supercollider/sc3-plugins"
+EGIT_REPO_URI="https://github.com/supercollider/sc3-plugins.git"
+if [[ ${PV} == *9999 ]]; then
+	KEYWORDS=""
+else
+	EGIT_COMMIT="Version-${PV}"
+	KEYWORDS="~amd64"
+fi
+LICENSE="GPL-2"
+SLOT="0"
+
+IUSE=""
+RESTRICT="mirror"
+
+RDEPEND="
+	media-sound/supercollider
+"
+DEPEND="${RDEPEND}
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-3.9.1-cmake-fix-nova-tt-nova-diskio-check.patch
+)
+
+src_configure() {
+	local mycmakeargs=(
+		-DSC_PATH=/usr/include/SuperCollider
+		-DAY=ON
+		-DSUPERNOVA=ON
+	)
+
+	cmake-utils_src_configure
+}

--- a/media-sound/sc3-plugins/sc3-plugins-9999.ebuild
+++ b/media-sound/sc3-plugins/sc3-plugins-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -25,10 +25,6 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}
 "
-
-PATCHES=(
-	"${FILESDIR}"/${PN}-3.9.1-cmake-fix-nova-tt-nova-diskio-check.patch
-)
 
 src_configure() {
 	local mycmakeargs=(


### PR DESCRIPTION
The relevant changes have been merged upstream, see https://github.com/supercollider/sc3-plugins/pull/229