### PR TITLE
Add CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,112 @@
+version: 2.1
+
+jobs:
+  check new versions:
+    machine: true
+    steps:
+      - checkout
+      - run: ./tests/newversioncheck.sh
+  emerge random ebuild:
+    machine: true
+    steps:
+      - checkout
+      - restore_cache:
+          key: portage-pkgdir-emerge
+      - run: ./tests/emerge-random-ebuild.sh
+      - save_cache:
+          key: portage-pkgdir-emerge-{{ epoch }}
+          paths:
+            - ~/.portage-pkgdir
+  emerge random live ebuild:
+    machine: true
+    steps:
+      - checkout
+      - restore_cache:
+          key: portage-pkgdir-emerge
+      - run: ./tests/emerge-random-live-ebuild.sh
+      - save_cache:
+          key: portage-pkgdir-emerge-{{ epoch }}
+          paths:
+            - ~/.portage-pkgdir
+  repoman:
+    machine: true
+    steps:
+      - checkout
+      - restore_cache:
+          key: portage-pkgdir-repoman
+      - run: ./tests/repoman.sh
+      - save_cache:
+          key: portage-pkgdir-repoman-{{ epoch }}
+          paths:
+            - ~/.portage-pkgdir
+  emerge new or changed ebuilds:
+    machine: true
+    steps:
+      - checkout
+      - restore_cache:
+          key: portage-pkgdir-emerge
+      - run: ./tests/emerge-new-or-changed-ebuilds.sh
+      - save_cache:
+          key: portage-pkgdir-emerge-{{ epoch }}
+          paths:
+            - ~/.portage-pkgdir
+  generate site:
+    machine: true
+    steps:
+      - checkout
+      - run: ./docs/generate-site.sh
+      - persist_to_workspace:
+          root: docs/site
+          paths:
+            - index.md
+  deploy site:
+    machine: true
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/docs
+      - run: .circleci/deploy-gh-pages.sh
+
+
+workflows:
+  version: 2
+  daily tests:
+    triggers:
+     - schedule:
+         cron: "0 16 * * *"
+         filters:
+           branches:
+             only:
+               - master
+    jobs:
+      - check new versions
+      - emerge random ebuild
+      - emerge random live ebuild:
+          requires:
+            - emerge random ebuild
+  pullrequest:
+    jobs:
+      - repoman:
+          filters:
+            branches:
+              ignore: master
+      - emerge new or changed ebuilds:
+          requires:
+            - repoman
+          filters:
+            branches:
+              ignore: master
+  update site:
+    jobs:
+      - generate site:
+          filters:
+            branches:
+              only:
+                - master
+      - deploy site:
+          requires:
+            - generate site
+          filters:
+            branches:
+              only:
+                - master

--- a/.circleci/deploy-gh-pages.sh
+++ b/.circleci/deploy-gh-pages.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Commit generated docs to gh-pages branch
+set -e
+
+git config user.email "${GITHUB_EMAIL}"
+git config user.name "${GITHUB_NAME}"
+
+set -x
+git checkout gh-pages
+cp /tmp/docs/* .
+git add -A .
+git commit --allow-empty -m "Deploy commit ${CIRCLE_SHA1} to GitHub Pages [skip ci]"
+git show --stat-count=10 HEAD
+git push origin gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,19 +20,6 @@ matrix:
       language: generic
       sudo: required
       script: ./tests/emerge-new-or-changed-ebuilds.sh
-    - if: type != pull_request AND type != cron
-      os: linux
-      services: docker
-      language: generic
-      sudo: required
-      script: ./docs/generate-site.sh
-      deploy:
-        provider: pages
-        skip-cleanup: true
-        local-dir: docs/site
-        github-token: $GITHUB_API_TOKEN
-        target-branch: gh-pages
-        keep-history: false
     - if: type = cron
       os: linux
       services: docker

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Audio overlay [![Build Status](https://travis-ci.org/gentoo-audio/audio-overlay.svg?branch=master)](https://travis-ci.org/gentoo-audio/audio-overlay)
+# Audio overlay [![Build Status](https://travis-ci.org/gentoo-audio/audio-overlay.svg?branch=master)](https://travis-ci.org/gentoo-audio/audio-overlay) [![CircleCI](https://circleci.com/gh/gentoo-audio/audio-overlay.svg?style=svg)](https://circleci.com/gh/gentoo-audio/audio-overlay)
 
 Gentoo/Funtoo overlay containing pro audio applications
 
@@ -19,7 +19,7 @@ Join us at the `#proaudio-overlay` channel at `irc.freenode.org` or [create an i
 ## Quality control
 - GitHub's [branch protection](https://help.github.com/articles/about-protected-branches/) is enabled for the `master` branch.
 - Changes can only be done using [pull requests](https://help.github.com/articles/about-pull-requests/) and need at least one approval.
-- Pull requests can only be merged if they pass the automated tests, which are run by [Travis CI](https://travis-ci.org/gentoo-audio/audio-overlay).
+- Pull requests can only be merged if they pass the automated tests, which are run by [Travis CI](https://travis-ci.org/gentoo-audio/audio-overlay) and [CircleCI](https://circleci.com/gh/gentoo-audio/audio-overlay).
 <br>We have a zero-tolerance policy for test failures and warnings, only changes that have no failures and warnings are merged.
 
 ### Automated tests
@@ -27,28 +27,27 @@ All tests that are meant to be executed by the user or by CI can be found in the
 
 All tests need `app-emulation/docker` to be installed.
 
+The `emerge` and `repoman` tests will create and use a binary package cache at `${HOME}/.portage-pkgdir`.
+
 #### Pull Requests
 Every pull request must pass the following tests before it can be merged:
 - Validation if the ebuild(s), metadata and other overlay files are correct. This is done using [repoman](https://wiki.gentoo.org/wiki/Repoman).
 <br>Run this test using `./tests/repoman.sh`.
 - Validation if the ebuilds that are new or changed in the Pull Request can be emerged. This is done in a clean amd64 stage3.
 <br>Run this test using `./tests/emerge-new-or-changed-ebuilds.sh` from the branch which contains the new or changed ebuild(s).
-<br>Note that this will create a binary package cache at `${HOME}/.portage-pkgdir`.
 
 #### Daily checks
 Every day the following tests are run:
 - A random ebuild is picked and emerged to validate that it can still be emerged correctly. This is done in a clean amd64 stage3.
 <br>Run this test using `./tests/emerge-random-ebuild.sh`.
-<br>Note that this will create a binary package cache at `${HOME}/.portage-pkgdir`.
+- A random live ebuild is picked and emerged to validate that it can still be emerged correctly. This is done in a clean amd64 stage3.
+<br>Run this test using `./tests/emerge-random-live-ebuild.sh`.
 - A check if a new version of any of the packages in the overlay is released. This is done using [newversionchecker](https://github.com/simonvanderveldt/newversionchecker). If a new version has been released an issue requesting a version bump will be created.
 <br>Run this test using `./tests/newversioncheck.sh`.
 
 #### Development
-To check if an ebuild you're working on can be emerged without issue use `./tests/emerge-ebuild.sh <path>/<to>/<ebuild>.ebuild`. This is done in a clean amd64 stage3.
+To check if an ebuild you're working on can be emerged without issue use `./tests/emerge-ebuild.sh <path>/<to>/<ebuild>.ebuild`. This script will emerge the chosen ebuild in a clean amd64 stage3.
 <br>For example to emerge the ebuild `media-sound/somesynth/somesynth-1.2.3.ebuild` run `./tests/emerge-ebuild.sh media-sound/somesynth/somesynth-1.2.3.ebuild`.
-<br>Note that this will create a binary package cache at `${HOME}/.portage-pkgdir`.
-
-Also see the tests described under [Pull Requests](#pull-requests).
 
 #### Test configuration
 All test configuration can be found in `./tests/resources`.

--- a/docs/generate-site.sh
+++ b/docs/generate-site.sh
@@ -15,9 +15,11 @@ docker create --name portage gentoo/portage
 mkdir -p docs/site
 rm -rf docs/site/*
 
+# The sed replacement is a workaround for an issue on CircleCI where the echo'd output
+# gets prefixed with "^@^@"
 docker run --rm -ti \
   --volumes-from portage \
   -v "${HOME}/.portage-pkgdir":/usr/portage/packages \
   -v "${PWD}":/usr/local/portage \
   -w /usr/local/portage simonvanderveldt/overlay-packagelist \
-  docs/index.md.j2 > docs/site/index.md
+  docs/index.md.j2 | sed -e "s/^\^@\^@//" > docs/site/index.md

--- a/tests/emerge-new-or-changed-ebuilds.sh
+++ b/tests/emerge-new-or-changed-ebuilds.sh
@@ -5,7 +5,17 @@ set -ex
 SCRIPT_PATH=$(dirname "$0")
 
 # Get list of new or changed ebuilds
-EBUILDS=($(git diff --name-only --diff-filter=d "${TRAVIS_BRANCH:-master}" | grep '\.ebuild$')) || true
+if [[ ! -z "${CIRCLECI}" ]]; then
+  # For some reason CircleCI does some crazy stuff with git/master which breaks the normal git workflow :|
+  # See https://discuss.circleci.com/t/checkout-script-adds-commits-to-master-from-circle-branch/14194
+  # So we hard reset master here to make it usable again
+  git checkout master
+  git reset --hard origin/master
+  git checkout -
+  EBUILDS=($(git diff --name-only --diff-filter=d "master..${CIRCLE_BRANCH}" | grep '\.ebuild$')) || true
+else
+  EBUILDS=($(git diff --name-only --diff-filter=d "${TRAVIS_BRANCH:-master}" | grep '\.ebuild$')) || true
+fi
 
 # Emerge the ebuilds in a clean stage3
 for EBUILD in "${EBUILDS[@]}"

--- a/tests/emerge-random-ebuild.sh
+++ b/tests/emerge-random-ebuild.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Emerge a random non-live ebuild out of all the ebuilds in the overlay in a clean amd64 stage3
 # Used to do continuous tests if our ebuilds still work
-# As well as making sure Travis's cache of the master branch is filled
+# as well as make sure the binary package cache is updated on our CI service
 set -ex
 
 SCRIPT_PATH=$(dirname "$0")

--- a/tests/emerge-random-live-ebuild.sh
+++ b/tests/emerge-random-live-ebuild.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Emerge a random live ebuild out of all the ebuilds in the overlay in a clean amd64 stage3
 # Used to do continuous tests if our ebuilds still work
-# As well as making sure Travis's cache of the master branch is filled
+# as well as make sure the binary package cache is updated on our CI service
 set -ex
 
 SCRIPT_PATH=$(dirname "$0")

--- a/tests/repoman.sh
+++ b/tests/repoman.sh
@@ -15,12 +15,19 @@ docker pull gentoo/stage3-amd64
 
 # Run the repoman tests in a clean stage3
 docker run --rm -ti \
+  -e GITHUB_TOKEN \
+  -e TRAVIS \
   -e TRAVIS_REPO_SLUG \
   -e TRAVIS_PULL_REQUEST \
-  -e TRAVIS_BOT_GITHUB_TOKEN \
   -e TRAVIS_SECURE_ENV_VARS \
+  -e CIRCLECI \
+  -e CIRCLE_PROJECT_USERNAME \
+  -e CIRCLE_PROJECT_REPONAME \
+  -e CIRCLE_PULL_REQUEST \
+  -e CIRCLE_PR_NUMBER \
   --volumes-from portage \
   -v "${HOME}/.portage-pkgdir":/usr/portage/packages \
   -v "${PWD}":/usr/local/portage \
-  -w /usr/local/portage gentoo/stage3-amd64 \
+  -w /usr/local/portage \
+  gentoo/stage3-amd64 \
   /usr/local/portage/tests/resources/repoman.sh

--- a/tests/resources/repoman.sh
+++ b/tests/resources/repoman.sh
@@ -14,21 +14,9 @@ PATH="~/.local/bin:$PATH"
 # Run the tests
 if ! repoman_output=$(repoman full -d -q); then
   echo "$repoman_output"
-  # Don't report back to GitHub for third-party pull requests
-  # This is to prevent build failures because the required encrypted env vars are missing for 3rd party PRs
-  if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
-    echo "$repoman_output" | travis-bot --description "Repoman QA results:"
-  else
-    echo "Skipping posting repoman QA results to GitHub because TRAVIS_SECURE_ENV_VARS is not 'true'"
-  fi
+  echo "$repoman_output" | travis-bot --description "Repoman QA results:"
   exit 1
 else
   echo "$repoman_output"
-  # Don't report back to GitHub for third-party pull requests
-  # This is to prevent build failures because the required encrypted env vars are missing for 3rd party PRs
-  if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
-    echo "$repoman_output" | travis-bot --description "Repoman QA results:"
-  else
-    echo "Skipping posting repoman QA results to GitHub because TRAVIS_SECURE_ENV_VARS is not 'true'"
-  fi
+  echo "$repoman_output" | travis-bot --description "Repoman QA results:"
 fi


### PR DESCRIPTION
This PR adds the required config to run our tests on CircleCI.
This should fix #244 in that the timeout on CircleCI is significantly longer (5 hours as far as I've been able to find) and it's easier to cache portage package cache between steps in a pipeline (called workflow in CircleCI terms) as well, which significantly speeds up the emerge tests.

I'd like to run this in parallel to Travis for a month or so to see how well it works.

Since only one service can/should update the GitHub Pages site I've removed publishing to GitHub Pages from the Travis config.

I've tested all jobs and all of them worked as expected, but I expect there will still be some small things that will cause problems. I'll fix those when they pop up.