### PR TITLE
Readme: add eselect repository instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Gentoo/Funtoo overlay containing pro audio applications
 
 ## How to use this overlay
-- Add the following entry to [`/etc/portage/repos.conf`](https://wiki.gentoo.org/wiki//etc/portage/repos.conf) and sync using `emerge --sync`
+- If you manage [`/etc/portage/repos.conf`](https://wiki.gentoo.org/wiki//etc/portage/repos.conf) manually add the following entry:
 ```ini
 [audio-overlay]
 location = /<path>/<to>/<your>/<overlays>/audio-overlay
@@ -11,7 +11,14 @@ sync-type = git
 sync-uri = https://github.com/gentoo-audio/audio-overlay.git
 auto-sync = yes
 ```
-- Or if you use [layman](https://wiki.gentoo.org/wiki/Layman) add the overlay using `layman -a audio-overlay` and sync using `layman -s audio-overlay`
+- If you use [eselect repository](https://wiki.gentoo.org/wiki/Eselect/Repository) enable this overlay using:
+```
+eselect repository enable audio-overlay
+```
+- If you use [layman](https://wiki.gentoo.org/wiki/Layman) add this overlay using:
+```
+layman -a audio-overlay
+```
 
 ## Contact
 Join us at the `#proaudio-overlay` channel at `irc.freenode.org` or [create an issue](https://github.com/gentoo-audio/audio-overlay/issues/new).


### PR DESCRIPTION
Small update to the readme to add `eselect repository` instructions