### PR TITLE
Fix incorrect use of PYTHON_REQUIRED_USE when using python-any-r1

### DIFF
--- a/media-libs/libmonome/libmonome-9999.ebuild
+++ b/media-libs/libmonome/libmonome-9999.ebuild
@@ -22,7 +22,6 @@ LICENSE="ISC"
 SLOT="0"
 
 IUSE="osc -python udev"
-REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 RDEPEND="udev? ( virtual/libudev )
 	osc? ( media-libs/liblo )

--- a/media-sound/serialosc/serialosc-9999.ebuild
+++ b/media-sound/serialosc/serialosc-9999.ebuild
@@ -23,7 +23,6 @@ LICENSE="ISC"
 SLOT="0"
 
 IUSE="-zeroconf"
-REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 RDEPEND="virtual/libudev
 	media-libs/liblo

--- a/tests/repoman.sh
+++ b/tests/repoman.sh
@@ -12,7 +12,7 @@ PACKAGES=""
 if [[ -n "${CIRCLE_PULL_REQUEST}" ]]; then
   # Get list of new or changed packages
   IFS=" " read -ra EBUILDS <<< "$("${SCRIPT_PATH}/get-new-or-changed-ebuilds.sh")"
-  IFS=" " read -ra PACKAGES <<< "$(for EBUILD in "${EBUILDS[@]}"; do dirname "${EBUILD}"; done | sort -u)"
+  mapfile -t PACKAGES < <(for EBUILD in "${EBUILDS[@]}"; do dirname "${EBUILD}"; done | sort -u)
   echo "Running repoman on the following packages:" "${PACKAGES[@]}"
 fi
 

--- a/tests/resources/repoman.sh
+++ b/tests/resources/repoman.sh
@@ -23,17 +23,17 @@ if [[ -n "${1}" ]]; then
   for PACKAGE in "${PACKAGES[@]}"
   do
     pushd "${PACKAGE}"
-    REPOMAN_OUTPUT+=$(repoman full -d -q) || REPOMAN_EXITCODES+=${?}
+    REPOMAN_OUTPUT+="${PACKAGE}: $(repoman full -d -q)\n" || REPOMAN_EXITCODES+=${?}
     popd
   done
 else
   REPOMAN_OUTPUT+=$(repoman full -d -q) || REPOMAN_EXITCODES+=${?}
 fi
 
-echo "${REPOMAN_OUTPUT}"
+echo -e "${REPOMAN_OUTPUT}"
 # Post repoman output as comment on PR when running on CI
 if [[ -n "${CIRCLE_PULL_REQUEST}" ]]; then
-  echo "${REPOMAN_OUTPUT}" | travis-bot --description "Repoman QA results:"
+  echo -e "${REPOMAN_OUTPUT}" | travis-bot --description "Repoman QA results:"
 fi
 
 if (( REPOMAN_EXITCODES > 0 )); then


### PR DESCRIPTION
These caused failures ever since `python-any-r1` was patched to fail in case `PYTHON_REQUIRED_USE` was used together with `python-any-r`, see https://github.com/gentoo/gentoo/pull/12492