### PR TITLE
bitwig-studio: Replace x11-libs/cairo[xcb] with x11-libs/cairo[X]

### DIFF
--- a/media-sound/bitwig-studio/bitwig-studio-1.3.16.ebuild
+++ b/media-sound/bitwig-studio/bitwig-studio-1.3.16.ebuild
@@ -34,7 +34,7 @@ RDEPEND="${DEPEND}
 	virtual/ffmpeg
 	virtual/opengl
 	virtual/udev
-	x11-libs/cairo[xcb]
+	x11-libs/cairo[X]
 	x11-libs/libX11
 	x11-libs/libXau
 	x11-libs/libXcursor

--- a/media-sound/bitwig-studio/bitwig-studio-2.5.1.ebuild
+++ b/media-sound/bitwig-studio/bitwig-studio-2.5.1.ebuild
@@ -35,7 +35,7 @@ RDEPEND="${DEPEND}
 	virtual/opengl
 	virtual/udev
 	x11-libs/gtk+:3
-	x11-libs/cairo[xcb]
+	x11-libs/cairo[X]
 	x11-libs/libX11
 	x11-libs/libXau
 	x11-libs/libXcursor


### PR DESCRIPTION
The xcb USE flag has been dropped and it's config option are now triggered using the X USE flag