### PR TITLE
Unmask pyliblo

### DIFF
--- a/profiles/package.unmask
+++ b/profiles/package.unmask
@@ -1,0 +1,4 @@
+# Unmask pyliblo. We need it as a dependency for Carla and mididings
+# It has been masked because it's going to be dropped from the gentoo tree, see https://bugs.gentoo.org/708172
+# It has been added to this overlay to ensure it stays available even after it gets dropped from the gentoo tree
+media-libs/pyliblo


### PR DESCRIPTION
There are no users in the gentoo tree anymore so it's been masked as a preparation to drop it
We have some packages that depend on it in this overlay, so we've copied it into this overlay and need to unmask it to override the mask put in place in the gentoo tree