### PR TITLE
media-sound/ladish: Drop option to build the GUI

### DIFF
--- a/media-sound/ladish/files/ladish-1-gui-resources-only-when-enabled.patch
+++ b/media-sound/ladish/files/ladish-1-gui-resources-only-when-enabled.patch
@@ -1,0 +1,55 @@
+From 1df687a4069a8f55ed5cc4001d9c3ad2dff59d1b Mon Sep 17 00:00:00 2001
+From: Simon van der Veldt <simon.vanderveldt@gmail.com>
+Date: Wed, 23 Sep 2020 21:02:00 +0200
+Subject: [PATCH] wscript: Only install gladish resources when GUI is enabled
+
+---
+ wscript | 28 ++++++++++++++--------------
+ 1 file changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/wscript b/wscript
+index 296a8522..8f1d7499 100644
+--- a/wscript
++++ b/wscript
+@@ -592,24 +592,24 @@ def build(bld):
+ 
+         # GtkBuilder UI definitions (XML)
+         bld.install_files('${DATA_DIR}', 'gui/gladish.ui')
+-    
+-    bld.install_files('${PREFIX}/bin', 'ladish_control', chmod=0755)
+ 
+-    # 'Desktop' file (menu entry, icon, etc)
+-    bld.install_files('${PREFIX}/share/applications/', 'gui/gladish.desktop', chmod=0644)
++        # 'Desktop' file (menu entry, icon, etc)
++        bld.install_files('${PREFIX}/share/applications/', 'gui/gladish.desktop', chmod=0644)
++
++        # Icons
++        icon_sizes = ['16x16', '22x22', '24x24', '32x32', '48x48', '256x256']
++        for icon_size in icon_sizes:
++            bld.path.ant_glob('art/' + icon_size + '/apps/*.png')
++            bld.install_files('${PREFIX}/share/icons/hicolor/' + icon_size + '/apps/', 'art/' + icon_size + '/apps/gladish.png')
+ 
+-    # Icons
+-    icon_sizes = ['16x16', '22x22', '24x24', '32x32', '48x48', '256x256']
+-    for icon_size in icon_sizes:
+-        bld.path.ant_glob('art/' + icon_size + '/apps/*.png')
+-        bld.install_files('${PREFIX}/share/icons/hicolor/' + icon_size + '/apps/', 'art/' + icon_size + '/apps/gladish.png')
++        status_images = []
++        for status in ["down", "unloaded", "started", "stopped", "warning", "error"]:
++            status_images.append("art/status_" + status + ".png")
+ 
+-    status_images = []
+-    for status in ["down", "unloaded", "started", "stopped", "warning", "error"]:
+-        status_images.append("art/status_" + status + ".png")
++        bld.install_files('${DATA_DIR}', status_images)
++        bld.install_files('${DATA_DIR}', "art/ladish-logo-128x128.png")
+ 
+-    bld.install_files('${DATA_DIR}', status_images)
+-    bld.install_files('${DATA_DIR}', "art/ladish-logo-128x128.png")
++    bld.install_files('${PREFIX}/bin', 'ladish_control', chmod=0755)
+     bld.install_files('${DATA_DIR}', ["AUTHORS", "README", "NEWS"])
+     bld.install_as('${DATA_DIR}/COPYING', "gpl2.txt")
+ 
+-- 
+2.26.2
+

--- a/media-sound/ladish/files/ladish-9999-gui-resources-only-when-enabled.patch
+++ b/media-sound/ladish/files/ladish-9999-gui-resources-only-when-enabled.patch
@@ -1,0 +1,53 @@
+From 89bf2533a902b962f1154be3b6e67999c3f57dfb Mon Sep 17 00:00:00 2001
+From: Simon van der Veldt <simon.vanderveldt@gmail.com>
+Date: Wed, 23 Sep 2020 21:22:34 +0200
+Subject: [PATCH] wscript: Only install gladish resources when GUI is enabled
+
+---
+ wscript | 26 +++++++++++++-------------
+ 1 file changed, 13 insertions(+), 13 deletions(-)
+
+diff --git a/wscript b/wscript
+index a7594716..5f482003 100644
+--- a/wscript
++++ b/wscript
+@@ -634,23 +634,23 @@ def build(bld):
+         # GtkBuilder UI definitions (XML)
+         bld.install_files('${DATA_DIR}', 'gui/gladish.ui')
+ 
+-    bld.install_files('${PREFIX}/bin', 'ladish_control', chmod=0755)
++        # 'Desktop' file (menu entry, icon, etc)
++        bld.install_files('${PREFIX}/share/applications/', 'gui/gladish.desktop', chmod=0644)
+ 
+-    # 'Desktop' file (menu entry, icon, etc)
+-    bld.install_files('${PREFIX}/share/applications/', 'gui/gladish.desktop', chmod=0644)
++        # Icons
++        icon_sizes = ['16x16', '22x22', '24x24', '32x32', '48x48', '256x256']
++        for icon_size in icon_sizes:
++            bld.path.ant_glob('art/' + icon_size + '/apps/*.png')
++            bld.install_files('${PREFIX}/share/icons/hicolor/' + icon_size + '/apps/', 'art/' + icon_size + '/apps/gladish.png')
+ 
+-    # Icons
+-    icon_sizes = ['16x16', '22x22', '24x24', '32x32', '48x48', '256x256']
+-    for icon_size in icon_sizes:
+-        bld.path.ant_glob('art/' + icon_size + '/apps/*.png')
+-        bld.install_files('${PREFIX}/share/icons/hicolor/' + icon_size + '/apps/', 'art/' + icon_size + '/apps/gladish.png')
++        status_images = []
++        for status in ["down", "unloaded", "started", "stopped", "warning", "error"]:
++            status_images.append("art/status_" + status + ".png")
+ 
+-    status_images = []
+-    for status in ["down", "unloaded", "started", "stopped", "warning", "error"]:
+-        status_images.append("art/status_" + status + ".png")
++        bld.install_files('${DATA_DIR}', status_images)
++        bld.install_files('${DATA_DIR}', "art/ladish-logo-128x128.png")
+ 
+-    bld.install_files('${DATA_DIR}', status_images)
+-    bld.install_files('${DATA_DIR}', "art/ladish-logo-128x128.png")
++    bld.install_files('${PREFIX}/bin', 'ladish_control', chmod=0755)
+     bld.install_files('${DATA_DIR}', ["AUTHORS", "README", "NEWS"])
+     bld.install_as('${DATA_DIR}/COPYING', "gpl2.txt")
+ 
+-- 
+2.26.2
+

--- a/media-sound/ladish/ladish-1-r1.ebuild
+++ b/media-sound/ladish/ladish-1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -14,16 +14,17 @@ if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="https://github.com/LADI/${PN}.git"
 	KEYWORDS=""
+	EGIT_SUBMODULES=()
 else
 	inherit vcs-snapshot
 	SRC_URI="https://github.com/LADI/ladish/archive/${P}.tar.gz"
 	KEYWORDS="~amd64"
 fi
-EGIT_SUBMODULES=()
-
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="debug doc gtk lash python"
+RESTRICT="mirror"
+
+IUSE="debug doc lash python"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}
 	python? ( lash ) "
 
@@ -32,15 +33,6 @@ RDEPEND="media-libs/alsa-lib
 	sys-apps/dbus
 	dev-libs/expat
 	lash? ( !media-sound/lash )
-	gtk? (
-		dev-libs/glib
-		dev-libs/dbus-glib
-		>=x11-libs/gtk+-2.20.0:2
-		dev-cpp/gtkmm:2.4
-		>=dev-cpp/libgnomecanvasmm-2.6.0
-		x11-libs/flowcanvas
-		dev-libs/boost
-	)
 	${PYTHON_DEPS}"
 DEPEND="${RDEPEND}
 	doc? ( app-doc/doxygen )
@@ -52,6 +44,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-configure-gladish.patch"
 	"${FILESDIR}/${P}-configure-libdir.patch"
 	"${FILESDIR}/${P}-add-includes-for-getrlimit.patch"
+	"${FILESDIR}/${P}-gui-resources-only-when-enabled.patch"
 )
 
 src_prepare()
@@ -66,7 +59,6 @@ src_configure() {
 		--distnodeps
 		$(usex debug --debug '')
 		$(usex doc --doxygen '')
-		$(usex gtk '--enable-gladish' '')
 		$(usex lash '--enable-liblash' '')
 		$(usex python '--enable-pylash' '')
 	)

--- a/media-sound/ladish/ladish-9999.ebuild
+++ b/media-sound/ladish/ladish-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -14,16 +14,17 @@ if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="https://github.com/LADI/${PN}.git"
 	KEYWORDS=""
+	EGIT_SUBMODULES=()
 else
 	inherit vcs-snapshot
 	SRC_URI="https://github.com/LADI/ladish/archive/${P}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~amd64"
 fi
-EGIT_SUBMODULES=()
-
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="debug doc gtk lash python"
+RESTRICT="mirror"
+
+IUSE="debug doc lash python"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}
 	python? ( lash ) "
 
@@ -32,15 +33,6 @@ RDEPEND="media-libs/alsa-lib
 	sys-apps/dbus
 	dev-libs/expat
 	lash? ( !media-sound/lash )
-	gtk? (
-		dev-libs/glib
-		dev-libs/dbus-glib
-		>=x11-libs/gtk+-2.20.0:2
-		dev-cpp/gtkmm:2.4
-		>=dev-cpp/libgnomecanvasmm-2.6.0
-		x11-libs/flowcanvas
-		dev-libs/boost
-	)
 	${PYTHON_DEPS}"
 DEPEND="${RDEPEND}
 	doc? ( app-doc/doxygen )
@@ -50,6 +42,7 @@ DOCS=( AUTHORS README NEWS )
 
 PATCHES=(
 	"${FILESDIR}/${PN}-configure-gladish.patch"
+	"${FILESDIR}/${P}-gui-resources-only-when-enabled.patch"
 )
 
 src_prepare()
@@ -64,7 +57,6 @@ src_configure() {
 		--distnodeps
 		$(usex debug --debug '')
 		$(usex doc --doxygen '')
-		$(usex gtk '--enable-gladish' '')
 		$(usex lash '--enable-liblash' '')
 		$(usex python '--enable-pylash' '')
 	)


### PR DESCRIPTION
flowcanvas has been removed from the gentoo tree and is no longer maintained. Since the gladish GUI is 90% flowcanvas there's no way to have the GUI without it, so remove the option to build the GUI/gladish
This also fixes the installation of the .desktop file and icons to be conditional on if the GUI is built or not, before they were always installed even if the GUI wasn't built.

This fixes the repoman failure we currently have for this package