### PR TITLE
tests: Ensure we always use dev-lang/rust-bin

### DIFF
--- a/tests/resources/emerge-ebuild.sh
+++ b/tests/resources/emerge-ebuild.sh
@@ -22,6 +22,9 @@ fi
 export FEATURES="binpkg-multi-instance -news -ipc-sandbox -network-sandbox -pid-sandbox"
 export PORTAGE_RSYNC_EXTRA_OPTS="-q"
 
+# Ensure we use dev-lang/rust-bin
+echo "dev-lang/rust" > /etc/portage/package.mask
+
 # Show emerge info for troubleshooting purposes
 emerge --info
 

--- a/tests/resources/repoman.sh
+++ b/tests/resources/repoman.sh
@@ -13,6 +13,9 @@ fi
 # Also disable rsync's output
 export FEATURES="binpkg-multi-instance -news -ipc-sandbox -network-sandbox -pid-sandbox" PORTAGE_RSYNC_EXTRA_OPTS="-q"
 
+# Ensure we use dev-lang/rust-bin
+echo "dev-lang/rust" > /etc/portage/package.mask
+
 # Install dependencies
 emerge -q --buildpkg --usepkg dev-vcs/git app-portage/repoman dev-python/pip
 pip install --user https://github.com/simonvanderveldt/travis-github-pr-bot/archive/master.zip


### PR DESCRIPTION
Otherwise we're waiting for ages to compile dev-lang/rust just because it's a dependency of librsvg nowadays