### PR TITLE
tests: Only install tools and do configuration required for the tests once

### DIFF
--- a/tests/resources/emerge-ebuild.sh
+++ b/tests/resources/emerge-ebuild.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Tests emering of an ebuild, installs dependencies first
-# Takes the path to an ebuild as the one and only argument
+# Tests emering of one or multiple ebuilds, installs dependencies first
+# Takes the path to an ebuild or a list of ebuild paths as argument(s)
 # Sources ebuild specific config from ./packages/<category>/<PN>.conf and
 # ./packages/<category>/<P>.conf if those files exist
 # Depends on qatom from app-portage/portage-utils
@@ -17,8 +17,8 @@ fi
 
 # Enable binpkg-multi-instance mainly for keeping binpkgs built with different USE flags
 # Disable news messages from portage as well as the IPC, network and PID sandbox to get rid of the
-# "Unable to unshare: EPERM" messages without requiring the container to be ran in priviliged mode
-# Also disable rsync's output
+# "Unable to unshare: EPERM" messages without requiring the container to be run in privileged mode
+# Disable rsync output
 export FEATURES="binpkg-multi-instance -news -ipc-sandbox -network-sandbox -pid-sandbox"
 export PORTAGE_RSYNC_EXTRA_OPTS="-q"
 
@@ -33,33 +33,31 @@ emerge --info
 emerge --quiet-build --buildpkg --usepkg sys-libs/libcap
 emerge --quiet-build --buildpkg --usepkg --update --changed-use --deep --with-bdeps=y @world
 
-EBUILD_PATHS=("${@}")
+# Emerge utilities/tools used by this script
+emerge -q --buildpkg --usepkg app-portage/portage-utils
 
-# Emerge the ebuilds in a clean stage3
-for EBUILD_PATH in "${EBUILD_PATHS[@]}"
-do
-  echo "Emerging ${EBUILD_PATH}"
-  echo "Emerging dependencies"
-  emerge -q --buildpkg --usepkg app-portage/portage-utils
+# Set portage's distdir to /tmp/distfiles
+# This is a workaround for a bug in portage/git-r3 where git-r3 can't
+# create the distfiles/git-r3 directory when no other distfiles have been
+# downloaded by portage first, which happens when using binary packages
+# https://bugs.gentoo.org/481434
+export DISTDIR="/tmp/distfiles"
 
-  EBUILD_FILENAME=$(basename "${EBUILD_PATH}" ".ebuild")
-  EBUILD_CATEGORY="${EBUILD_PATH%%/*}"
-  EBUILD="${EBUILD_CATEGORY}/${EBUILD_FILENAME}"
-  echo "Emerging ${EBUILD}"
-
-  # Set portage's distdir to /tmp/distfiles
-  # This is a workaround for a bug in portage/git-r3 where git-r3 can't
-  # create the distfiles/git-r3 directory when no other distfiles have been
-  # downloaded by portage first, which happens when using binary packages
-  # https://bugs.gentoo.org/481434
-  export DISTDIR="/tmp/distfiles"
-
-  # Setup overlay
-  mkdir -p /etc/portage/repos.conf
-  cat > /etc/portage/repos.conf/localrepo.conf <<EOF
+# Setup overlay
+mkdir -p /etc/portage/repos.conf
+cat > /etc/portage/repos.conf/localrepo.conf <<EOF
 [audio-overlay]
 location = /usr/local/portage
 EOF
+
+# Emerge the ebuilds in a clean stage3
+EBUILD_PATHS=("${@}")
+for EBUILD_PATH in "${EBUILD_PATHS[@]}"
+do
+  echo "Emerging ${EBUILD_PATH}"
+  EBUILD_FILENAME=$(basename "${EBUILD_PATH}" ".ebuild")
+  EBUILD_CATEGORY="${EBUILD_PATH%%/*}"
+  EBUILD="${EBUILD_CATEGORY}/${EBUILD_FILENAME}"
 
   # Source ebuild specific env vars
   unset ACCEPT_KEYWORDS
@@ -77,9 +75,11 @@ EOF
   fi
 
   # Emerge dependencies first
+  echo "Emerging dependencies"
   emerge --quiet-build --buildpkg --usepkg --onlydeps --autounmask=y --autounmask-continue=y "=${PKG_CATEGORY}/${PKG_FULL_NAME}"
 
   # Emerge the ebuild itself
+  echo "Emerging ${EBUILD}"
   emerge -v "=${PKG_CATEGORY}/${PKG_FULL_NAME}"
 
   # Unmerge ebuild in case we're emerging multiple ebuilds to prevent blocking other ebuilds


### PR DESCRIPTION
I noticed we were accidentally running some steps for every package when emerging multiple ebuilds instead of just once.
This PR cleans up the `emerge-ebuild.sh` script a bit, move common config out of the per package section, add some logging, fix some comments.

Bonus: It saves about 8% of time for the emerge of all non-live ebuilds vs before from my local testing (+-58 minutes instead of +-63) :)