### PR TITLE
Replace virtual/ffmpeg with media-video/ffmpeg

### DIFF
--- a/media-sound/bitwig-studio/bitwig-studio-1.3.16.ebuild
+++ b/media-sound/bitwig-studio/bitwig-studio-1.3.16.ebuild
@@ -31,7 +31,7 @@ RDEPEND="${DEPEND}
 	media-libs/libpng:0/16
 	media-libs/mesa
 	sys-libs/zlib
-	virtual/ffmpeg
+	media-video/ffmpeg
 	virtual/opengl
 	virtual/udev
 	x11-libs/cairo[X]

--- a/media-sound/bitwig-studio/bitwig-studio-2.5.1.ebuild
+++ b/media-sound/bitwig-studio/bitwig-studio-2.5.1.ebuild
@@ -31,7 +31,7 @@ RDEPEND="${DEPEND}
 	media-libs/libpng:0/16
 	media-libs/mesa
 	sys-libs/zlib
-	virtual/ffmpeg
+	media-video/ffmpeg
 	virtual/opengl
 	virtual/udev
 	x11-libs/gtk+:3

--- a/media-sound/bitwig-studio/bitwig-studio-3.2.7.ebuild
+++ b/media-sound/bitwig-studio/bitwig-studio-3.2.7.ebuild
@@ -31,7 +31,7 @@ RDEPEND="${DEPEND}
 	media-libs/libpng:0/16
 	media-libs/mesa
 	sys-libs/zlib
-	virtual/ffmpeg
+	media-video/ffmpeg
 	virtual/opengl
 	virtual/udev
 	x11-libs/gtk+:3


### PR DESCRIPTION
`virtual/ffmpeg` has been dropped in https://github.com/gentoo/gentoo/commit/0e5b93b5315bdedab7c37f5bbe66b7fd60ba51ec update the ebuilds that depend on it to `media-video/ffmpeg`