### PR TITLE
media-libs/libmonome: Enable Python 3.7

### DIFF
--- a/media-libs/libmonome/libmonome-9999.ebuild
+++ b/media-libs/libmonome/libmonome-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-PYTHON_COMPAT=( python2_7 python3_4 python3_5 python3_6 )
+PYTHON_COMPAT=( python2_7 python3_4 python3_5 python3_6 python3_7 )
 PYTHON_REQ_USE='threads(+)'
 
 inherit python-any-r1 waf-utils
@@ -20,6 +20,7 @@ else
 fi
 LICENSE="ISC"
 SLOT="0"
+RESTRICT="mirror"
 
 IUSE="osc -python udev"
 


### PR DESCRIPTION
Python 2.7 is no longer included in the upstream stage3 after syncing so currently emering this packages fails because there are no compatible Python implementations available. Python 3.7 works fine in my local testing so enabling it here.

@marcan I'm not sure if this warrants a revbump, do you know?