### PR TITLE
media-plugins/deteriorate-lv2: Add missing PYTHON_DEPS to DEPEND

### DIFF
--- a/media-plugins/deteriorate-lv2/deteriorate-lv2-1.0.6.ebuild
+++ b/media-plugins/deteriorate-lv2/deteriorate-lv2-1.0.6.ebuild
@@ -29,4 +29,5 @@ RDEPEND="dev-cpp/gtkmm:2.4
 	media-libs/lv2
 	media-libs/lvtk[gtk2]"
 
-DEPEND="${RDEPEND}"
+DEPEND="${PYTHON_DEPS}
+	${RDEPEND}"

--- a/media-plugins/deteriorate-lv2/deteriorate-lv2-9999.ebuild
+++ b/media-plugins/deteriorate-lv2/deteriorate-lv2-9999.ebuild
@@ -29,4 +29,5 @@ RDEPEND="dev-cpp/gtkmm:2.4
 	media-libs/lv2
 	media-libs/lvtk[gtk2]"
 
-DEPEND="${RDEPEND}"
+DEPEND="${PYTHON_DEPS}
+	${RDEPEND}"


### PR DESCRIPTION
Small fix for missing `PYTHON_DEPS` in `DEPEND`, triggered by deteriorate-lv2 failing to emerge on CI because no supported Python implementation was available.
There might be more packages that are missing this, I'll do a check this weekend.