### PR TITLE
tests: Remove unused guitarix config

### DIFF
--- a/tests/emerge-new-or-changed-ebuilds.sh
+++ b/tests/emerge-new-or-changed-ebuilds.sh
@@ -10,7 +10,9 @@ SCRIPT_PATH=$(dirname "$0")
 
 IFS=" " read -ra EBUILDS <<< "$("${SCRIPT_PATH}/get-new-or-changed-ebuilds.sh")"
 
-echo "Detected changes to the following ebuilds: ${EBUILDS[@]}"
-
-# Emerge the ebuilds in a clean stage3
-"${SCRIPT_PATH}/emerge-ebuild.sh" "${EBUILDS[@]}"
+if [ ${#EBUILDS[@]} -eq 0 ]; then
+  echo "No changed ebuilds found, skipping emerge tests"
+else
+  echo "Emerging the following ebuilds:" "${EBUILDS[@]}"
+  "${SCRIPT_PATH}/emerge-ebuild.sh" "${EBUILDS[@]}"
+fi

--- a/tests/resources/packages/media-sound/guitarix.conf
+++ b/tests/resources/packages/media-sound/guitarix.conf
@@ -1,4 +1,0 @@
-cat >/etc/portage/package.use/audio-overlay <<EOF
-dev-cpp/cairomm X
-dev-cpp/gtkmm X
-EOF


### PR DESCRIPTION
The guitarix package has been remove since it's not available in the upstream gentoo repo but the test config was still there :)