### PR TITLE
media-plugins/fabla: Drop GCC9 patch from live ebuild

### DIFF
--- a/media-plugins/fabla/fabla-1.3.2-r1.ebuild
+++ b/media-plugins/fabla/fabla-1.3.2-r1.ebuild
@@ -1,1 +1,38 @@
-fabla-1.9999.ebuild
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cmake
+
+DESCRIPTION="LV2 drum sampler plugin"
+HOMEPAGE="http://openavproductions.com/fabla"
+if [[ ${PV} == *9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/openAVproductions/openAV-Fabla.git"
+	KEYWORDS=""
+else
+	SRC_URI="https://github.com/openAVproductions/openAV-Fabla/archive/release-${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64"
+	S="${WORKDIR}/openAV-Fabla-release-${PV}"
+	RESTRICT="mirror"
+fi
+LICENSE="GPL-2"
+SLOT="1"
+
+IUSE=""
+
+RDEPEND="media-libs/lv2
+	media-libs/libsndfile
+	>=x11-libs/ntk-1.3.1000
+	media-libs/mesa"
+DEPEND="${RDEPEND}"
+
+PATCHES="${FILESDIR}/${PN}-1-gcc-9-remove-leading-underscore.patch"
+
+src_prepare() {
+	# Fix hardcoded libdir
+	sed -i -e "s|lib/lv2|$(get_libdir)/lv2|" CMakeLists.txt || die "sed failed"
+
+	cmake_src_prepare
+}

--- a/media-plugins/fabla/fabla-1.9999.ebuild
+++ b/media-plugins/fabla/fabla-1.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -27,8 +27,6 @@ RDEPEND="media-libs/lv2
 	>=x11-libs/ntk-1.3.1000
 	media-libs/mesa"
 DEPEND="${RDEPEND}"
-
-PATCHES="${FILESDIR}/${PN}-1-gcc-9-remove-leading-underscore.patch"
 
 src_prepare() {
 	# Fix hardcoded libdir


### PR DESCRIPTION
It's been fixed in https://github.com/openAVproductions/openAV-Fabla/pull/61