### PR TITLE
media-plugins/nekobi: update patch

### DIFF
--- a/media-plugins/nekobi/files/nekobi-allow-configuring-which-plugin-types-to-build.patch
+++ b/media-plugins/nekobi/files/nekobi-allow-configuring-which-plugin-types-to-build.patch
@@ -2,12 +2,6 @@ From 1ae960dc5fade7122cbe34f072fb326a6f07bea1 Mon Sep 17 00:00:00 2001
 From: Simon van der Veldt <simon.vanderveldt@gmail.com>
 Date: Fri, 28 Apr 2017 12:46:09 +0200
 Subject: [PATCH] Allow configuring which plugin types to build
-
----
- Makefile                | 4 ++++
- plugins/Nekobi/Makefile | 6 ++++++
- 2 files changed, 10 insertions(+)
-
 diff --git a/Makefile b/Makefile
 index a548af5..da90442 100644
 --- a/Makefile
@@ -26,24 +20,29 @@ index a548af5..da90442 100644
  	@$(CURDIR)/dpf/utils/generate-vst-bundles.sh
  endif
 diff --git a/plugins/Nekobi/Makefile b/plugins/Nekobi/Makefile
-index e9b6de7..c0d6eff 100644
+index a81f825..494ba60 100644
 --- a/plugins/Nekobi/Makefile
 +++ b/plugins/Nekobi/Makefile
-@@ -36,20 +36,26 @@ ifeq ($(HAVE_JACK),true)
- TARGETS += jack
- endif
+@@ -33,7 +33,11 @@ LINK_FLAGS += -lpthread
+ # --------------------------------------------------------------
+ # Enable all possible plugin types
  
++ifeq ($(HAVE_JACK),true)
+ TARGETS += jack
++endif
++
 +ifeq ($(BUILD_DSSI),true)
  TARGETS += dssi_dsp
- ifeq ($(HAVE_DGL),true)
- ifeq ($(HAVE_LIBLO),true)
+ 
+ ifeq ($(HAVE_CAIRO_OR_OPENGL),true)
+@@ -41,14 +45,19 @@ ifeq ($(HAVE_LIBLO),true)
  TARGETS += dssi_ui
  endif
  endif
 +endif
  
 +ifeq ($(BUILD_LV2),true)
- ifeq ($(HAVE_DGL),true)
+ ifeq ($(HAVE_CAIRO_OR_OPENGL),true)
  TARGETS += lv2_sep
  else
  TARGETS += lv2_dsp
@@ -56,6 +55,3 @@ index e9b6de7..c0d6eff 100644
  
  all: $(TARGETS)
  
--- 
-2.26.2
-


### PR DESCRIPTION
Upstream updates Makefiles, so I updated patch.

Personnaly, I avoid patches in live ebuilds I rather try to add sed lines to src_prepare because they are more tolerant to file changes and simple offsetting than patches.

I know gentoo policy encourages patches for more readability, but for live ebuild this is non sense.
I don't think it improves readability for my part, but still stick to this policy for versionned ebuild.
Generally sed lines in live ebuilds helps me nicely to update versioned patches.