### PR TITLE
media-sound/{carla,cadence}: Fix PYTHON_USEDEP

### DIFF
--- a/media-sound/cadence/cadence-9999-r7.ebuild
+++ b/media-sound/cadence/cadence-9999-r7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -18,8 +18,8 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 RDEPEND="${PYTHON_DEPS}
 	media-sound/jack2[dbus]
-	$(python_gen_cond_dep 'dev-python/PyQt5[dbus,gui,opengl?,svg,widgets,${PYTHON_MULTI_USEDEP}]')
-	$(python_gen_cond_dep 'dev-python/dbus-python[${PYTHON_MULTI_USEDEP}]')
+	$(python_gen_cond_dep 'dev-python/PyQt5[dbus,gui,opengl?,svg,widgets,${PYTHON_USEDEP}]')
+	$(python_gen_cond_dep 'dev-python/dbus-python[${PYTHON_USEDEP}]')
 	a2jmidid? ( media-sound/a2jmidid[dbus] )
 	ladish? ( >=media-sound/ladish-9999 )
 	pulseaudio? ( media-sound/pulseaudio[jack] )"

--- a/media-sound/carla/carla-9999-r1.ebuild
+++ b/media-sound/carla/carla-9999-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -27,7 +27,7 @@ IUSE="alsa gtk gtk2 opengl osc -pulseaudio rdf sf2 sndfile X"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 RDEPEND="${PYTHON_DEPS}
-	$(python_gen_cond_dep 'dev-python/PyQt5[gui,opengl?,svg,widgets,${PYTHON_MULTI_USEDEP}]')
+	$(python_gen_cond_dep 'dev-python/PyQt5[gui,opengl?,svg,widgets,${PYTHON_USEDEP}]')
 	virtual/jack
 	alsa? ( media-libs/alsa-lib )
 	gtk? ( x11-libs/gtk+:3 )


### PR DESCRIPTION
The ebuild used PYTHON_MULTI_USEDEP inside python_gen_cond_dep. However,
according to python-single-r1.eclass(5), only PYTHON_SINGLE_USEDEP and
PYTHON_USEDEP can be set, where PYTHON_USEDEP is probably what was
intended by the original ebuild maintainer.

This commit updates the ebuild by using PYTHON_USEDEP instead of
PYTHON_MULTI_USEDEP.

Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Adrian Schollmeyer <nex+b-g-o@nexadn.de>