### PR TITLE
media-libs/pyliblo: Add tests, PEP517 and recent python versions

### DIFF
--- a/media-libs/pyliblo/pyliblo-0.10.0-r2.ebuild
+++ b/media-libs/pyliblo/pyliblo-0.10.0-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7,8,9} )
+PYTHON_COMPAT=( python3_{8..11} )
 DISTUTILS_USE_PEP517=setuptools
 inherit distutils-r1
 

--- a/media-libs/pyliblo/pyliblo-0.10.0-r2.ebuild
+++ b/media-libs/pyliblo/pyliblo-0.10.0-r2.ebuild
@@ -4,6 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_{6,7,8,9} )
+DISTUTILS_USE_PEP517=setuptools
 inherit distutils-r1
 
 DESCRIPTION="A Python wrapper for the liblo OSC library"

--- a/media-libs/pyliblo/pyliblo-0.10.0-r2.ebuild
+++ b/media-libs/pyliblo/pyliblo-0.10.0-r2.ebuild
@@ -19,3 +19,5 @@ RDEPEND=">=media-libs/liblo-0.27
 	${PYTHON_DEPS}"
 DEPEND="${RDEPEND}
 	dev-python/cython[${PYTHON_USEDEP}]"
+
+distutils_enable_tests unittest


### PR DESCRIPTION
These commits go alongside each other. Enabling tests is required for testing the python bumps.
Only using PEP517 is a minor quality improvement and independent of the rest of the changeset.

This PR is a requirement for building pyliblo on recent Gentoo systems without having to enable py3.9 support.