### PR TITLE
profiles: Drop pyliblo unmask

### DIFF
--- a/profiles/package.unmask
+++ b/profiles/package.unmask
@@ -1,4 +1,0 @@
-# Unmask pyliblo. We need it as a dependency for Carla
-# It has been masked because it's going to be dropped from the gentoo tree, see https://bugs.gentoo.org/708172
-# It has been added to this overlay to ensure it stays available even after it gets dropped from the gentoo tree
-media-libs/pyliblo


### PR DESCRIPTION
The unmask was added to circumvent problems during the migration of media-libs/pyliblo from ::gentoo to ::audio-overlay. Since it is now obsolete, this commit drops the unmask.

Signed-off-by: Adrian Schollmeyer <nex+b-g-o@nexadn.de>