### PR TITLE
*/*: Bump consumers of waf-utils.eclass to EAPI 8

### DIFF
--- a/media-libs/libmonome/libmonome-9999.ebuild
+++ b/media-libs/libmonome/libmonome-9999.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 PYTHON_COMPAT=( python2_7 python3_{6,7,8,9} )
 PYTHON_REQ_USE='threads(+)'
@@ -28,6 +28,7 @@ RDEPEND="udev? ( virtual/libudev )
 	osc? ( media-libs/liblo )
 	python? ( dev-python/cython )"
 DEPEND="${RDEPEND}"
+BDEPEND="${PYTHON_DEPS}"
 
 src_configure() {
 	local mywafconfargs=(

--- a/media-plugins/bitrot/bitrot-9999.ebuild
+++ b/media-plugins/bitrot/bitrot-9999.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 # Required by waf
 PYTHON_COMPAT=( python3_{6,7,8,9} )
@@ -16,7 +16,7 @@ KEYWORDS=""
 LICENSE="Apache-2.0"
 SLOT="0"
 
-DEPEND="${PYTHON_DEPS}"
+BDEPEND="${PYTHON_DEPS}"
 
 src_prepare() {
 	# Fix hardcoded libdir

--- a/media-plugins/deteriorate-lv2/deteriorate-lv2-9999.ebuild
+++ b/media-plugins/deteriorate-lv2/deteriorate-lv2-9999.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 # Required by waf
 PYTHON_COMPAT=( python3_{8,9} )
@@ -29,7 +29,7 @@ RDEPEND="dev-cpp/gtkmm:2.4
 	media-libs/lv2
 	media-libs/lvtk[gtk2]"
 
-DEPEND="${PYTHON_DEPS}
-	${RDEPEND}"
+DEPEND="${RDEPEND}"
+BDEPEND="${PYTHON_DEPS}"
 
 PATCHES="${FILESDIR}/${PN}-1.0.7-wscript-fix-duplicate-manifest-install.patch"

--- a/media-sound/serialosc/serialosc-9999.ebuild
+++ b/media-sound/serialosc/serialosc-9999.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 PYTHON_COMPAT=( python2_7 python3_{6,7,8,9} )
 PYTHON_REQ_USE='threads(+)'
@@ -30,6 +30,7 @@ RDEPEND="virtual/libudev
 	dev-libs/libuv
 	zeroconf? ( net-dns/avahi[mdnsresponder-compat] )"
 DEPEND="${RDEPEND}"
+BDEPEND="${PYTHON_DEPS}"
 
 src_configure() {
 	local mywafconfargs=(

--- a/x11-libs/ntk/ntk-9999.ebuild
+++ b/x11-libs/ntk/ntk-9999.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 # Required by waf
 PYTHON_COMPAT=( python3_{6,7,8,9} )
@@ -32,8 +32,8 @@ RDEPEND="x11-libs/libX11
 	virtual/jpeg:*
 	media-libs/libpng:*
 	opengl? ( media-libs/glu )"
-DEPEND="${PYTHON_DEPS}
-	${RDEPEND}"
+DEPEND="${RDEPEND}"
+BDEPEND="${PYTHON_DEPS}"
 
 PATCHES=( "${FILESDIR}/${PN}-dont-run-ldconfig.patch"
 	"${FILESDIR}/${PN}-no-default-cflags-optimizations.patch" )


### PR DESCRIPTION
waf-utils.eclass no longer supports EAPI=6. This PR bumps all consumers which still used EAPI=6 to use the most recent EAPI=8.

Closes: https://github.com/gentoo-audio/audio-overlay/issues/515