### PR TITLE
metadata: Deprecate EAPI 6

### DIFF
--- a/metadata/layout.conf
+++ b/metadata/layout.conf
@@ -2,3 +2,4 @@ masters = gentoo
 cache-formats = md5-dict
 thin-manifests = true
 eapis-banned = 0 1 2 3 4 5
+eapis-deprecated = 6


### PR DESCRIPTION
EAPI 6 is already very old and almost gone from ::gentoo. It is likely that it will be banned there sooner or later. It should at least be deprecated here and banned after migrating all ebuilds to newer EAPIs.

Signed-off-by: Adrian Schollmeyer <nex+b-g-o@nexadn.de>