### PR TITLE
media-sound/ladish: fix upstream URL, update PYTHON_COMPAT, minor QA fixes

### DIFF
--- a/media-sound/ladish/ladish-9999.ebuild
+++ b/media-sound/ladish/ladish-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{6,7,8,9} )
+PYTHON_COMPAT=( python3_{9..11} )
 PYTHON_REQ_USE='threads(+)'
 
 inherit flag-o-matic python-single-r1 waf-utils

--- a/media-sound/ladish/ladish-9999.ebuild
+++ b/media-sound/ladish/ladish-9999.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 PYTHON_COMPAT=( python3_{6,7,8,9} )
 PYTHON_REQ_USE='threads(+)'
@@ -12,13 +12,10 @@ DESCRIPTION="LADI Session Handler - a session management system for JACK applica
 HOMEPAGE="https://ladish.org"
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="https://git.nedk.org/lad/ladish.git"
-	KEYWORDS=""
-	EGIT_SUBMODULES=()
+	EGIT_REPO_URI="https://github.com/LADI/ladish.git"
+	EGIT_BRANCH="main"
 else
-	inherit vcs-snapshot
-	SRC_URI="https://github.com/LADI/ladish/archive/${P}.tar.gz
-		https://git.nedk.org/lad/ladish.git/plain/waf -> ${P}-waf-2.0.22"
+	SRC_URI="https://github.com/LADI/ladish/archive/${P}.tar.gz"
 	KEYWORDS="~amd64"
 fi
 LICENSE="GPL-2"
@@ -44,6 +41,8 @@ PATCHES=(
 	"${FILESDIR}/${P}-disable-gladish.patch"
 )
 
+QA_SONAME=( ".*/libalsapid.so" )
+
 src_prepare()
 {
 	sed -i -e "s/RELEASE = False/RELEASE = True/" wscript
@@ -65,4 +64,6 @@ src_install() {
 	use doc && HTML_DOCS="${S}/build/default/html/*"
 	waf-utils_src_install
 	python_fix_shebang "${ED}"
+
+	rm "${ED}/usr/share/ladish/COPYING" || die
 }

--- a/media-sound/ladish/ladish-9999.ebuild
+++ b/media-sound/ladish/ladish-9999.ebuild
@@ -31,9 +31,13 @@ RDEPEND="media-libs/alsa-lib
 	dev-libs/expat
 	lash? ( !media-sound/lash )
 	${PYTHON_DEPS}"
-DEPEND="${RDEPEND}
+DEPEND="${RDEPEND}"
+BDEPEND="
+	dev-util/intltool
+	virtual/pkgconfig
+
 	doc? ( app-doc/doxygen )
-	virtual/pkgconfig"
+"
 
 DOCS=( AUTHORS README NEWS )
 


### PR DESCRIPTION
This one's required to make ladish compile again. The old upstream is dead. The rest is just fixing stuff while at it.