### PR TITLE
media-sound/cadence: bump PYTHON_COMPAT to py3.10, QA fixes

### DIFF
--- a/media-sound/cadence/cadence-9999-r7.ebuild
+++ b/media-sound/cadence/cadence-9999-r7.ebuild
@@ -1,9 +1,9 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
-PYTHON_COMPAT=( python3_{6,7,8,9} )
+PYTHON_COMPAT=( python3_10 )
 inherit git-r3 python-single-r1 gnome2-utils
 
 DESCRIPTION="Collection of tools useful for audio production"
@@ -13,7 +13,7 @@ KEYWORDS=""
 LICENSE="GPL-2"
 SLOT="0"
 
-IUSE="-pulseaudio a2jmidid ladish opengl"
+IUSE="pulseaudio a2jmidid ladish opengl"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 RDEPEND="${PYTHON_DEPS}


### PR DESCRIPTION
Closes: https://github.com/gentoo-audio/audio-overlay/issues/516