### PR TITLE
bitrot, monome: bump PYTHON_COMPAT to py3.10 and py3.11

### DIFF
--- a/media-libs/libmonome/libmonome-9999.ebuild
+++ b/media-libs/libmonome/libmonome-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{8..9} )
+PYTHON_COMPAT=( python3_{10..11} )
 PYTHON_REQ_USE='threads(+)'
 
 inherit python-any-r1 waf-utils

--- a/media-libs/libmonome/libmonome-9999.ebuild
+++ b/media-libs/libmonome/libmonome-9999.ebuild
@@ -13,7 +13,6 @@ HOMEPAGE="https://github.com/monome/libmonome"
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="https://github.com/monome/libmonome.git"
-	KEYWORDS=""
 else
 	SRC_URI="https://github.com/monome/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~amd64"

--- a/media-plugins/bitrot/bitrot-9999.ebuild
+++ b/media-plugins/bitrot/bitrot-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 # Required by waf
-PYTHON_COMPAT=( python3_{6,7,8,9} )
+PYTHON_COMPAT=( python3_10 )
 PYTHON_REQ_USE='threads(+)'
 
 inherit git-r3 python-any-r1 waf-utils


### PR DESCRIPTION
Closes: https://github.com/gentoo-audio/audio-overlay/issues/532