### PR TITLE
*/*: Python bumps required to fix global scope failures

### DIFF
--- a/media-plugins/deteriorate-lv2/deteriorate-lv2-9999.ebuild
+++ b/media-plugins/deteriorate-lv2/deteriorate-lv2-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 # Required by waf
-PYTHON_COMPAT=( python3_{8,9} )
+PYTHON_COMPAT=( python3_10 )
 PYTHON_REQ_USE='threads(+)'
 
 inherit python-any-r1 waf-utils

--- a/media-sound/ladish/ladish-1-r2.ebuild
+++ b/media-sound/ladish/ladish-1-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7,8,9} )
+PYTHON_COMPAT=( python3_{10,11} )
 PYTHON_REQ_USE='threads(+)'
 
 inherit flag-o-matic python-single-r1 waf-utils

--- a/media-sound/serialosc/serialosc-1.4.1.ebuild
+++ b/media-sound/serialosc/serialosc-1.4.1.ebuild
@@ -1,1 +1,0 @@
-serialosc-9999.ebuild

--- a/media-sound/serialosc/serialosc-1.4.3.ebuild
+++ b/media-sound/serialosc/serialosc-1.4.3.ebuild
@@ -1,0 +1,1 @@
+serialosc-9999.ebuild

--- a/media-sound/serialosc/serialosc-9999.ebuild
+++ b/media-sound/serialosc/serialosc-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{8..9} )
+PYTHON_COMPAT=( python3_{10..11} )
 PYTHON_REQ_USE='threads(+)'
 NO_WAF_LIBDIR=yes
 


### PR DESCRIPTION
We have a bunch of software which is py3.9 or lower only. Since py3.9 is now deprecated in ::gentoo and py3.9 is removed from dependencies' PYTHON_COMPAT, we need to at least bump to py3.10 for these packages to work. This is done in this PR.

Closes: #535 
