### PR TITLE
media-sound/carla: enable py3.11

### DIFF
--- a/media-sound/carla/carla-9999-r1.ebuild
+++ b/media-sound/carla/carla-9999-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6,7,8,9,10} )
+PYTHON_COMPAT=( python3_{10,11} )
 inherit python-single-r1 xdg-utils
 
 DESCRIPTION="Fully-featured audio plugin host, supports many audio drivers and plugin formats"


### PR DESCRIPTION
Enables py3.11 and cleans up removed python targets.