### PR TITLE
media-libs/pyliblo: block cython-3

### DIFF
--- a/media-libs/pyliblo/pyliblo-0.10.0-r2.ebuild
+++ b/media-libs/pyliblo/pyliblo-0.10.0-r2.ebuild
@@ -19,6 +19,6 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 RDEPEND=">=media-libs/liblo-0.27
 	${PYTHON_DEPS}"
 DEPEND="${RDEPEND}
-	dev-python/cython[${PYTHON_USEDEP}]"
+	<dev-python/cython-3[${PYTHON_USEDEP}]"
 
 distutils_enable_tests unittest


### PR DESCRIPTION
pyliblo breaks with Cython 3, so we must block it.